### PR TITLE
Add message pack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ ryu = "1.0"
 serde-transcode = "1.1"
 blake3 = { version = "0.3", default-features = false }
 chrono = "0.4.18"
+rmp-serde = "0.14"
 
 rkv = { version = "0.15", optional = true }
 bincode = { version = "1.3.1", optional = true }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1,6 +1,7 @@
 use crate::util::dfs_serializer;
 use base64::DecodeError;
 use core::num::ParseIntError;
+use rmp_serde as serde_mgpk;
 use serde_cbor;
 use serde_json;
 use thiserror::Error;
@@ -21,6 +22,12 @@ pub enum Error {
     CBORSerializationError {
         #[from]
         source: serde_cbor::Error,
+    },
+
+    #[error("MessagePack Serialization error")]
+    MsgPackSerializationError {
+        #[from]
+        source: serde_mgpk::encode::Error,
     },
 
     #[error("DFS Serialization error")]

--- a/src/event_message/serialization_info.rs
+++ b/src/event_message/serialization_info.rs
@@ -1,5 +1,6 @@
 use crate::error::Error;
 use core::str::FromStr;
+use rmp_serde as serde_mgpk;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Copy)]
@@ -14,9 +15,7 @@ impl SerializationFormats {
         match self {
             Self::JSON => serde_json::to_vec(message).map_err(|e| e.into()),
             Self::CBOR => serde_cbor::to_vec(message).map_err(|e| e.into()),
-            Self::MGPK => Err(Error::SerializationError(
-                "MessagePack unimplemented".to_string(),
-            )),
+            Self::MGPK => serde_mgpk::to_vec(message).map_err(|e| e.into()),
         }
     }
 


### PR DESCRIPTION
Adds support for MessagePack as an event serialization format.

NOTE: there are currently no cannonical examples of messagepack-encoded events, so there is currently no test, however the same is true of CBOR. This PR may be deferred.