### PR TITLE
Backhash checking

### DIFF
--- a/src/event/event_data/rotation.rs
+++ b/src/event/event_data/rotation.rs
@@ -22,7 +22,6 @@ pub struct RotationEvent {
 impl EventSemantics for RotationEvent {
     fn apply_to(&self, state: IdentifierState) -> Result<IdentifierState, Error> {
         Ok(IdentifierState {
-            last: self.previous_event_hash.clone(),
             current: Signatory {
                 threshold: self.key_config.threshold,
                 signers: self.key_config.public_keys.clone(),

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -32,7 +32,7 @@ impl EventSemantics for Event {
         match self.event_data {
             EventData::Icp(_) => {
                 // ICP events require the state to be uninitialized
-                if state != IdentifierState::default() || self.sn != 0 {
+                if state.prefix != IdentifierPrefix::default() || self.sn != 0 {
                     return Err(Error::SemanticError("SN is not correct".to_string()));
                 }
             }
@@ -45,7 +45,6 @@ impl EventSemantics for Event {
                 }
             }
         };
-
         Ok(IdentifierState {
             sn: self.sn,
             prefix: self.prefix.clone(),

--- a/src/event_message/mod.rs
+++ b/src/event_message/mod.rs
@@ -124,37 +124,28 @@ impl SignedEventMessage {
 
 impl EventSemantics for EventMessage {
     fn apply_to(&self, state: IdentifierState) -> Result<IdentifierState, Error> {
+        // Update state.last with serialized current event message.
         match self.event.event_data {
             EventData::Icp(_) => {
                 if verify_identifier_binding(self)? {
-                    self.event.apply_to(state)
+                    self.event.apply_to(IdentifierState {
+                        last: self.serialize()?,
+                        ..state
+                    })
                 } else {
                     Err(Error::SemanticError(
                         "Invalid Identifier Prefix Binding".into(),
                     ))
                 }
             }
-            _ => self.event.apply_to(state),
-        }
-    }
-}
-
-impl EventSemantics for SignedEventMessage {
-    fn apply_to(&self, state: IdentifierState) -> Result<IdentifierState, Error> {
-        // Update state.last with serialized current event message.
-        let new_state = match &self.event_message.event.event_data {
-            EventData::Icp(_) => IdentifierState {
-                last: self.serialize()?,
-                ..state
-            },
-            EventData::Rot(rot) => {
+            EventData::Rot(ref rot) => {
                 // Check if hashes of state.last event and previous_event_hash matches.
                 if rot.previous_event_hash.derivation.derive(&state.last) == rot.previous_event_hash
                 {
-                    IdentifierState {
+                    self.event.apply_to(IdentifierState {
                         last: self.serialize()?,
                         ..state
-                    }
+                    })
                 } else {
                     return Err(Error::SemanticError(
                         "Last event does not match previous event".to_string(),
@@ -162,9 +153,13 @@ impl EventSemantics for SignedEventMessage {
                 }
             }
             _ => todo!(),
-        };
+        }
+    }
+}
 
-        self.event_message.apply_to(new_state)
+impl EventSemantics for SignedEventMessage {
+    fn apply_to(&self, state: IdentifierState) -> Result<IdentifierState, Error> {
+        self.event_message.apply_to(state)
     }
 }
 
@@ -285,7 +280,7 @@ mod tests {
 
         assert_eq!(s0.prefix, IdentifierPrefix::Basic(pref0.clone()));
         assert_eq!(s0.sn, 0);
-        assert_eq!(s0.last, signed_event.serialize()?);
+        assert_eq!(s0.last, sed);
         assert_eq!(s0.current.signers.len(), 1);
         assert_eq!(s0.current.signers[0], pref0);
         assert_eq!(s0.current.threshold, 1);
@@ -377,7 +372,7 @@ mod tests {
 
         assert_eq!(s0.prefix, pref);
         assert_eq!(s0.sn, 0);
-        assert_eq!(s0.last, signed_event.serialize()?);
+        assert_eq!(s0.last, serialized);
         assert_eq!(s0.current.signers.len(), 2);
         assert_eq!(s0.current.signers[0], sig_pref_0);
         assert_eq!(s0.current.signers[1], enc_pref_0);

--- a/src/event_message/mod.rs
+++ b/src/event_message/mod.rs
@@ -141,7 +141,30 @@ impl EventSemantics for EventMessage {
 
 impl EventSemantics for SignedEventMessage {
     fn apply_to(&self, state: IdentifierState) -> Result<IdentifierState, Error> {
-        self.event_message.apply_to(state)
+        // Update state.last with serialized current event message.
+        let new_state = match &self.event_message.event.event_data {
+            EventData::Icp(_) => IdentifierState {
+                last: self.serialize()?,
+                ..state
+            },
+            EventData::Rot(rot) => {
+                // Check if hashes of state.last event and previous_event_hash matches.
+                if rot.previous_event_hash.derivation.derive(&state.last) == rot.previous_event_hash
+                {
+                    IdentifierState {
+                        last: self.serialize()?,
+                        ..state
+                    }
+                } else {
+                    return Err(Error::SemanticError(
+                        "Last event does not match previous event".to_string(),
+                    ));
+                }
+            }
+            _ => todo!(),
+        };
+
+        self.event_message.apply_to(new_state)
     }
 }
 
@@ -262,7 +285,7 @@ mod tests {
 
         assert_eq!(s0.prefix, IdentifierPrefix::Basic(pref0.clone()));
         assert_eq!(s0.sn, 0);
-        assert_eq!(s0.last, SelfAddressingPrefix::default());
+        assert_eq!(s0.last, signed_event.serialize()?);
         assert_eq!(s0.current.signers.len(), 1);
         assert_eq!(s0.current.signers[0], pref0);
         assert_eq!(s0.current.threshold, 1);
@@ -354,7 +377,7 @@ mod tests {
 
         assert_eq!(s0.prefix, pref);
         assert_eq!(s0.sn, 0);
-        assert_eq!(s0.last, SelfAddressingPrefix::default());
+        assert_eq!(s0.last, signed_event.serialize()?);
         assert_eq!(s0.current.signers.len(), 2);
         assert_eq!(s0.current.signers[0], sig_pref_0);
         assert_eq!(s0.current.signers[1], enc_pref_0);

--- a/src/event_message/tests/test_utils.rs
+++ b/src/event_message/tests/test_utils.rs
@@ -142,7 +142,7 @@ fn test_update_identifier_state(
     // Attach sign to event message.
     let signed_event = event_msg.sign(vec![attached_sig.clone()]);
 
-    // Applay event to current IdentifierState.
+    // Apply event to current IdentifierState.
     let new_state = state_data.state.verify_and_apply(&signed_event)?;
 
     // Check if current prefix can verify message and signature.
@@ -155,7 +155,7 @@ fn test_update_identifier_state(
     // Check if state is updated correctly.
     assert_eq!(new_state.prefix, IdentifierPrefix::Basic(identifier));
     assert_eq!(new_state.sn, state_data.sn);
-    assert_eq!(new_state.last, state_data.prev_event_hash);
+    assert_eq!(new_state.last, signed_event.serialize()?);
     assert_eq!(new_state.current.signers.len(), 1);
     assert_eq!(new_state.current.signers[0], current_pref);
     assert_eq!(new_state.current.threshold, 1);
@@ -168,7 +168,7 @@ fn test_update_identifier_state(
     let mut new_history = state_data.history_prefs.clone();
     new_history.push(current_pref);
     // Current event will be previous event for the next one, so return its hash.
-    let prev_event_hash = SelfAddressing::Blake3_256.derive(&sed);
+    let prev_event_hash = SelfAddressing::Blake3_256.derive(&signed_event.serialize()?);
     // Compute sn for next event.
     let next_sn = state_data.sn + 1;
 
@@ -181,9 +181,9 @@ fn test_update_identifier_state(
     })
 }
 
-/// For given sequence of EventTypes check whether `IdentifierState` is updated correctly
+/// For given sequence of EventTypes check wheather `IdentifierState` is updated correctly
 /// by applying `test_update_identifier_state` sequentially.
-pub fn test_mock_event_sequence(sequence: Vec<EventType>) -> Result<(TestStateData), Error> {
+pub fn test_mock_event_sequence(sequence: Vec<EventType>) -> Result<TestStateData, Error> {
     let mut st = get_initial_test_data();
 
     let step = |event_type, state_data: Result<TestStateData, Error>| {

--- a/src/event_message/tests/test_utils.rs
+++ b/src/event_message/tests/test_utils.rs
@@ -155,7 +155,7 @@ fn test_update_identifier_state(
     // Check if state is updated correctly.
     assert_eq!(new_state.prefix, IdentifierPrefix::Basic(identifier));
     assert_eq!(new_state.sn, state_data.sn);
-    assert_eq!(new_state.last, signed_event.serialize()?);
+    assert_eq!(new_state.last, sed);
     assert_eq!(new_state.current.signers.len(), 1);
     assert_eq!(new_state.current.signers[0], current_pref);
     assert_eq!(new_state.current.threshold, 1);
@@ -168,7 +168,7 @@ fn test_update_identifier_state(
     let mut new_history = state_data.history_prefs.clone();
     new_history.push(current_pref);
     // Current event will be previous event for the next one, so return its hash.
-    let prev_event_hash = SelfAddressing::Blake3_256.derive(&signed_event.serialize()?);
+    let prev_event_hash = SelfAddressing::Blake3_256.derive(&sed);
     // Compute sn for next event.
     let next_sn = state_data.sn + 1;
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -13,7 +13,7 @@ use signatory::Signatory;
 pub struct IdentifierState {
     pub prefix: IdentifierPrefix,
     pub sn: u64,
-    pub last: SelfAddressingPrefix,
+    pub last: Vec<u8>,
     pub current: Signatory,
     pub next: SelfAddressingPrefix,
     pub delegated_keys: Vec<DelegatedIdentifierState>,


### PR DESCRIPTION
In relation to #19 .
Changed `IdentifierState.last` type to `Vec<u8>` and set it to serialised previous event in `SignedEventMessage::apply_to` method.