### PR TITLE
Feat/23/validator receipt

### DIFF
--- a/src/event/event_data/mod.rs
+++ b/src/event/event_data/mod.rs
@@ -12,7 +12,7 @@ use self::{
     delegated::{DelegatedInceptionEvent, DelegatedRotationEvent},
     inception::InceptionEvent,
     interaction::InteractionEvent,
-    receipt::EventReceipt,
+    receipt::{ReceiptNonTransferable, ReceiptTransferable},
     rotation::RotationEvent,
 };
 
@@ -27,7 +27,8 @@ pub enum EventData {
     Ixn(InteractionEvent),
     Dip(DelegatedInceptionEvent),
     Drt(DelegatedRotationEvent),
-    Rct(EventReceipt),
+    Rct(ReceiptNonTransferable),
+    Vrc(ReceiptTransferable),
 }
 
 impl EventSemantics for EventData {
@@ -39,6 +40,7 @@ impl EventSemantics for EventData {
             Self::Dip(e) => e.apply_to(state),
             Self::Drt(e) => e.apply_to(state),
             Self::Rct(e) => e.apply_to(state),
+            Self::Vrc(e) => e.apply_to(state),
         }
     }
 }

--- a/src/event/event_data/receipt.rs
+++ b/src/event/event_data/receipt.rs
@@ -1,7 +1,32 @@
+use super::super::sections::seal::Seal;
+use crate::prefix::SelfAddressingPrefix;
 use crate::state::EventSemantics;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct EventReceipt {}
+pub struct ReceiptNonTransferable {}
 
-impl EventSemantics for EventReceipt {}
+impl EventSemantics for ReceiptNonTransferable {}
+
+/// Validator Receipt
+///
+/// Event Receipt which is suitable for creation by Transferable
+/// Identifiers. Provides both the signatures and a commitment to
+/// the latest establishment event of the Validator.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ReceiptTransferable {
+    /// Receipted Event Digest
+    ///
+    /// A Qualified Digest of the event which this receipt is made for.
+    #[serde(rename = "dig")]
+    pub receipted_event_digest: SelfAddressingPrefix,
+
+    /// Validator Location Seal
+    ///
+    /// An Event Seal which indicates the latest establishment event of
+    /// the Validator when the Receipt was made
+    #[serde(rename = "seal")]
+    pub validator_location_seal: Seal,
+}
+
+impl EventSemantics for ReceiptTransferable {}

--- a/src/event/event_data/receipt.rs
+++ b/src/event/event_data/receipt.rs
@@ -3,16 +3,23 @@ use crate::prefix::SelfAddressingPrefix;
 use crate::state::EventSemantics;
 use serde::{Deserialize, Serialize};
 
+/// Non-Transferrable Receipt
+///
+/// A receipt created by an Identifier of a non-transferrable type.
+/// Mostly intended for use by Witnesses.
+/// NOTE: This receipt has a unique structure to it's appended
+/// signatures
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ReceiptNonTransferable {}
 
 impl EventSemantics for ReceiptNonTransferable {}
 
-/// Validator Receipt
+/// Transferrable Receipt
 ///
 /// Event Receipt which is suitable for creation by Transferable
 /// Identifiers. Provides both the signatures and a commitment to
-/// the latest establishment event of the Validator.
+/// the latest establishment event of the receipt creator.
+/// Mostly intended for use by Validators
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ReceiptTransferable {
     /// Receipted Event Digest

--- a/src/event/event_data/receipt.rs
+++ b/src/event/event_data/receipt.rs
@@ -1,4 +1,4 @@
-use super::super::sections::seal::Seal;
+use super::super::sections::seal::EventSeal;
 use crate::prefix::SelfAddressingPrefix;
 use crate::state::EventSemantics;
 use serde::{Deserialize, Serialize};
@@ -33,7 +33,7 @@ pub struct ReceiptTransferable {
     /// An Event Seal which indicates the latest establishment event of
     /// the Validator when the Receipt was made
     #[serde(rename = "seal")]
-    pub validator_location_seal: Seal,
+    pub validator_location_seal: EventSeal,
 }
 
 impl EventSemantics for ReceiptTransferable {}


### PR DESCRIPTION
Implements the structure of the transferrable/validator receipts. closes #23. Non-transferrable receipts are still needed, however the arrangement of their appended signatures is different and requires some more work.