### PR TITLE
Align order of attributes in rotation event

### DIFF
--- a/src/event/sections/mod.rs
+++ b/src/event/sections/mod.rs
@@ -20,11 +20,11 @@ pub struct WitnessConfig {
     #[serde(rename = "toad", with = "SerHex::<Compact>")]
     pub tally: u64,
 
-    #[serde(rename = "adds")]
-    pub graft: Vec<IdentifierPrefix>,
-
     #[serde(rename = "cuts")]
     pub prune: Vec<IdentifierPrefix>,
+
+    #[serde(rename = "adds")]
+    pub graft: Vec<IdentifierPrefix>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]


### PR DESCRIPTION
The keripy ordering is different and we cannot verify
rotation event. With this fix we align with python implementation.