### PR TITLE
improve icp

### DIFF
--- a/src/event/event_data/inception.rs
+++ b/src/event/event_data/inception.rs
@@ -8,7 +8,7 @@ use crate::{
     event::Event,
     event_message::{serialization_info::SerializationFormats, EventMessage},
     prefix::IdentifierPrefix,
-    state::{signatory::Signatory, EventSemantics, IdentifierState},
+    state::{EventSemantics, IdentifierState},
 };
 use serde::{Deserialize, Serialize};
 
@@ -68,11 +68,7 @@ impl InceptionEvent {
 impl EventSemantics for InceptionEvent {
     fn apply_to(&self, state: IdentifierState) -> Result<IdentifierState, Error> {
         Ok(IdentifierState {
-            current: Signatory {
-                threshold: self.key_config.threshold,
-                signers: self.key_config.public_keys.clone(),
-            },
-            next: self.key_config.threshold_key_digest.clone(),
+            current: self.key_config.clone(),
             witnesses: self.witness_config.initial_witnesses.clone(),
             tally: self.witness_config.tally,
             ..state

--- a/src/event/event_data/inception.rs
+++ b/src/event/event_data/inception.rs
@@ -1,7 +1,14 @@
-use super::super::sections::{InceptionWitnessConfig, KeyConfig};
+use super::{
+    super::sections::{InceptionWitnessConfig, KeyConfig},
+    EventData,
+};
 use crate::{
+    derivation::self_addressing::SelfAddressing,
     error::Error,
-    state::{EventSemantics, IdentifierState},
+    event::Event,
+    event_message::{serialization_info::SerializationFormats, EventMessage},
+    prefix::IdentifierPrefix,
+    state::{signatory::Signatory, EventSemantics, IdentifierState},
 };
 use serde::{Deserialize, Serialize};
 
@@ -20,10 +27,52 @@ pub struct InceptionEvent {
     pub inception_configuration: Vec<String>,
 }
 
+impl InceptionEvent {
+    pub fn new(
+        key_config: KeyConfig,
+        witness_config: Option<InceptionWitnessConfig>,
+        inception_config: Option<Vec<String>>,
+    ) -> Self {
+        Self {
+            key_config,
+            witness_config: witness_config.map_or_else(|| InceptionWitnessConfig::default(), |w| w),
+            inception_configuration: inception_config.map_or_else(|| vec![], |c| c),
+        }
+    }
+
+    /// Incept Self Addressing
+    ///
+    /// Takes the inception data and creates an EventMessage based on it, with
+    /// using the given format and deriving a Self Addressing Identifier with the
+    /// given derivation method
+    pub fn incept_self_addressing(
+        self,
+        derivation: SelfAddressing,
+        format: SerializationFormats,
+    ) -> Result<EventMessage, Error> {
+        let prefix = IdentifierPrefix::SelfAddressing(derivation.derive(
+            &EventMessage::get_inception_data(&self, derivation, format)?,
+        ));
+
+        EventMessage::new(
+            Event {
+                prefix,
+                sn: 0,
+                event_data: EventData::Icp(self),
+            },
+            format,
+        )
+    }
+}
+
 impl EventSemantics for InceptionEvent {
     fn apply_to(&self, state: IdentifierState) -> Result<IdentifierState, Error> {
         Ok(IdentifierState {
-            current: self.key_config.clone(),
+            current: Signatory {
+                threshold: self.key_config.threshold,
+                signers: self.key_config.public_keys.clone(),
+            },
+            next: self.key_config.threshold_key_digest.clone(),
             witnesses: self.witness_config.initial_witnesses.clone(),
             tally: self.witness_config.tally,
             ..state

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -22,7 +22,7 @@ pub struct Event {
 }
 
 impl Event {
-    pub fn to_message(&self, format: &SerializationFormats) -> Result<EventMessage, Error> {
+    pub fn to_message(self, format: SerializationFormats) -> Result<EventMessage, Error> {
         EventMessage::new(self, format)
     }
 }

--- a/src/event_message/mod.rs
+++ b/src/event_message/mod.rs
@@ -245,11 +245,7 @@ mod tests {
             prefix: IdentifierPrefix::Basic(pref0.clone()),
             sn: 0,
             event_data: EventData::Icp(InceptionEvent {
-                key_config: KeyConfig {
-                    threshold: 1,
-                    public_keys: vec![pref0.clone()],
-                    threshold_key_digest: nxt.clone(),
-                },
+                key_config: KeyConfig::new(vec![pref0.clone()], nxt.clone(), Some(1)),
                 witness_config: InceptionWitnessConfig::default(),
                 inception_configuration: vec![],
             }),
@@ -323,11 +319,11 @@ mod tests {
         );
 
         let icp = InceptionEvent::new(
-            KeyConfig {
-                public_keys: vec![sig_pref_0.clone(), enc_pref_0.clone()],
-                threshold_key_digest: nexter_pref.clone(),
-                threshold: 1,
-            },
+            KeyConfig::new(
+                vec![sig_pref_0.clone(), enc_pref_0.clone()],
+                nexter_pref.clone(),
+                Some(1),
+            ),
             None,
             None,
         )

--- a/src/event_message/mod.rs
+++ b/src/event_message/mod.rs
@@ -322,35 +322,19 @@ mod tests {
                 .as_bytes(),
         );
 
-        let icp_data = InceptionEvent {
-            key_config: KeyConfig {
-                threshold: 1,
+        let icp = InceptionEvent::new(
+            KeyConfig {
                 public_keys: vec![sig_pref_0.clone(), enc_pref_0.clone()],
                 threshold_key_digest: nexter_pref.clone(),
+                threshold: 1,
             },
-            witness_config: InceptionWitnessConfig::default(),
-            inception_configuration: vec![],
-        };
+            None,
+            None,
+        )
+        .incept_self_addressing(SelfAddressing::Blake3_256, SerializationFormats::JSON)?;
 
-        let icp_data_message = EventMessage::get_inception_data(
-            &icp_data,
-            SelfAddressing::Blake3_256,
-            &SerializationFormats::JSON,
-        );
-
-        let pref = IdentifierPrefix::SelfAddressing(
-            SelfAddressing::Blake3_256.derive(&dfs_serializer::to_vec(&icp_data_message)?),
-        );
-
-        let icp_m = Event {
-            prefix: pref.clone(),
-            sn: 0,
-            event_data: EventData::Icp(icp_data),
-        }
-        .to_message(&SerializationFormats::JSON)?;
-
-        // serialised extracted dataset
-        let serialized = icp_m.serialize()?;
+        // serialised
+        let serialized = icp.serialize()?;
 
         // sign
         let sig = ed
@@ -360,13 +344,13 @@ mod tests {
 
         assert!(sig_pref_0.verify(&serialized, &attached_sig.signature)?);
 
-        let signed_event = icp_m.sign(vec![attached_sig]);
+        let signed_event = icp.sign(vec![attached_sig]);
 
         let s_ = IdentifierState::default();
 
         let s0 = s_.verify_and_apply(&signed_event)?;
 
-        assert_eq!(s0.prefix, pref);
+        assert_eq!(s0.prefix, icp.event.prefix);
         assert_eq!(s0.sn, 0);
         assert_eq!(s0.last, serialized);
         assert_eq!(s0.current.public_keys.len(), 2);

--- a/src/event_message/serialization_info.rs
+++ b/src/event_message/serialization_info.rs
@@ -51,12 +51,12 @@ pub struct SerializationInfo {
 }
 
 impl SerializationInfo {
-    pub fn new(kind: &SerializationFormats, size: usize) -> Self {
+    pub fn new(kind: SerializationFormats, size: usize) -> Self {
         Self {
             major_version: 1,
             minor_version: 0,
             size,
-            kind: *kind,
+            kind,
         }
     }
     pub fn to_str(&self) -> String {
@@ -120,7 +120,7 @@ impl Default for SerializationInfo {
 
 #[test]
 fn basic_serialize() -> Result<(), Error> {
-    let si = SerializationInfo::new(&SerializationFormats::JSON, 100);
+    let si = SerializationInfo::new(SerializationFormats::JSON, 100);
 
     let version_string = si.to_str();
     assert_eq!("KERI10JSON000064_".to_string(), version_string);

--- a/src/event_message/tests/test_utils.rs
+++ b/src/event_message/tests/test_utils.rs
@@ -160,7 +160,7 @@ fn test_update_identifier_state(
             current_pref.clone(),
             next_dig.clone(),
         );
-        event?.to_message(&SerializationFormats::JSON)
+        event?.to_message(SerializationFormats::JSON)
     }?;
 
     // Serialise event message before signing.

--- a/src/event_message/tests/test_utils.rs
+++ b/src/event_message/tests/test_utils.rs
@@ -49,11 +49,7 @@ fn create_mock_event(
             prefix: IdentifierPrefix::Basic(identifier),
             sn: sn,
             event_data: EventData::Icp(InceptionEvent {
-                key_config: KeyConfig {
-                    threshold: 1,
-                    public_keys: vec![curr_key],
-                    threshold_key_digest: nxt,
-                },
+                key_config: KeyConfig::new(vec![curr_key], nxt, Some(1)),
                 witness_config: InceptionWitnessConfig::default(),
                 inception_configuration: vec![],
             }),
@@ -63,11 +59,7 @@ fn create_mock_event(
             sn: sn,
             event_data: EventData::Rot(RotationEvent {
                 previous_event_hash: prev_event,
-                key_config: KeyConfig {
-                    threshold: 1,
-                    public_keys: vec![curr_key],
-                    threshold_key_digest: nxt,
-                },
+                key_config: KeyConfig::new(vec![curr_key], nxt, Some(1)),
                 witness_config: WitnessConfig::default(),
                 data: vec![],
             }),

--- a/src/keri/mod.rs
+++ b/src/keri/mod.rs
@@ -119,7 +119,7 @@ impl Keri {
                     data: vec![],
                 }),
             }
-            .to_message(&SerializationFormats::JSON)?
+            .to_message(SerializationFormats::JSON)?
         };
 
         let signature = self.key_manager.sign(&ev.serialize()?)?;
@@ -149,7 +149,7 @@ impl Keri {
                 data: vec![Seal::Digest(dig_seal)],
             }),
         }
-        .to_message(&SerializationFormats::JSON)?;
+        .to_message(SerializationFormats::JSON)?;
 
         let signature = self.key_manager.sign(&ev.serialize()?)?;
         let ixn = ev.sign(vec![AttachedSignaturePrefix::new(
@@ -274,7 +274,7 @@ impl Keri {
                 },
             }),
         }
-        .to_message(&SerializationFormats::JSON)?
+        .to_message(SerializationFormats::JSON)?
         .sign(vec![AttachedSignaturePrefix::new(
             SelfSigning::Ed25519Sha512,
             signature,


### PR DESCRIPTION
contains some API improvements for ICP events and some style fixes:
- avoid using `&` with empty enums, no need
- moves dfs serialization inside `get_inception_data`
- adds `new` to `InceptionEvent`
- adds `incept_self_addressing` to `InceptionEvent`, does all derivation and steps needed to go from inception data to a full inception `EventMessage`
- updates tests to new usage