### PR TITLE
parse &[u8] instead of &str

### DIFF
--- a/src/derivation/attached_signature_code.rs
+++ b/src/derivation/attached_signature_code.rs
@@ -52,13 +52,19 @@ impl FromStr for AttachedSignatureCode {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match &s[..1] {
-            "A" => Ok(Self::new(SelfSigning::Ed25519Sha512, b64_to_num(&s[1..2])?)),
+            "A" => Ok(Self::new(
+                SelfSigning::Ed25519Sha512,
+                b64_to_num(&s.as_bytes()[1..2])?,
+            )),
             "B" => Ok(Self::new(
                 SelfSigning::ECDSAsecp256k1Sha256,
-                b64_to_num(&s[1..2])?,
+                b64_to_num(&s.as_bytes()[1..2])?,
             )),
             "0" => match &s[1..3] {
-                "AA" => Ok(Self::new(SelfSigning::Ed448, b64_to_num(&s[3..4])?)),
+                "AA" => Ok(Self::new(
+                    SelfSigning::Ed448,
+                    b64_to_num(&s.as_bytes()[3..4])?,
+                )),
                 _ => Err(Error::DeserializationError),
             },
             _ => Err(Error::DeserializationError),
@@ -68,12 +74,12 @@ impl FromStr for AttachedSignatureCode {
 
 // returns the u16 from the lowest 2 bytes of the b64 string
 // currently only works for strings 4 chars or less
-pub fn b64_to_num(b64: &str) -> Result<u16, Error> {
+pub fn b64_to_num(b64: &[u8]) -> Result<u16, Error> {
     let slice = decode_config(
         match b64.len() {
-            1 => ["AAA", b64].join(""),
-            2 => ["AA", b64].join(""),
-            _ => b64.to_string(),
+            1 => [r"AAA".as_bytes(), b64].concat(),
+            2 => [r"AA".as_bytes(), b64].concat(),
+            _ => b64.to_owned(),
         },
         base64::URL_SAFE,
     )

--- a/src/event_message/parse.rs
+++ b/src/event_message/parse.rs
@@ -22,7 +22,7 @@ fn cbor_message(s: &[u8]) -> nom::IResult<&[u8], EventMessage> {
     }
 }
 
-pub fn message(s: &[u8]) -> nom::IResult<&[u8], EventMessage> {
+fn message(s: &[u8]) -> nom::IResult<&[u8], EventMessage> {
     alt((json_message, cbor_message))(s)
 }
 

--- a/src/event_message/parse.rs
+++ b/src/event_message/parse.rs
@@ -6,23 +6,23 @@ use crate::{
 use nom::{branch::*, combinator::*, error::ErrorKind, multi::*, sequence::*};
 use serde_transcode::transcode;
 
-fn json_message(s: &str) -> nom::IResult<&str, EventMessage> {
-    let mut stream = serde_json::Deserializer::from_slice(s.as_bytes()).into_iter::<EventMessage>();
+fn json_message(s: &[u8]) -> nom::IResult<&[u8], EventMessage> {
+    let mut stream = serde_json::Deserializer::from_slice(s).into_iter::<EventMessage>();
     match stream.next() {
         Some(Ok(event)) => Ok((&s[stream.byte_offset()..], event)),
         _ => Err(nom::Err::Error((s, ErrorKind::IsNot))),
     }
 }
 
-fn cbor_message(s: &str) -> nom::IResult<&str, EventMessage> {
-    let mut stream = serde_cbor::Deserializer::from_slice(s.as_bytes()).into_iter::<EventMessage>();
+fn cbor_message(s: &[u8]) -> nom::IResult<&[u8], EventMessage> {
+    let mut stream = serde_cbor::Deserializer::from_slice(s).into_iter::<EventMessage>();
     match stream.next() {
         Some(Ok(event)) => Ok((&s[stream.byte_offset()..], event)),
         _ => Err(nom::Err::Error((s, ErrorKind::IsNot))),
     }
 }
 
-fn message(s: &str) -> nom::IResult<&str, EventMessage> {
+pub fn message(s: &[u8]) -> nom::IResult<&[u8], EventMessage> {
     alt((json_message, cbor_message))(s)
 }
 
@@ -73,7 +73,7 @@ pub fn sed(s: &[u8]) -> nom::IResult<&[u8], Vec<u8>> {
 }
 
 /// extracts the count from the sig count code
-fn sig_count(s: &str) -> nom::IResult<&str, u16> {
+fn sig_count(s: &[u8]) -> nom::IResult<&[u8], u16> {
     let (rest, t) = tuple((
         map_parser(
             nom::bytes::complete::take(2u8),
@@ -91,21 +91,21 @@ fn sig_count(s: &str) -> nom::IResult<&str, u16> {
 }
 
 /// called on an attached signature stream starting with a sig count
-fn signatures(s: &str) -> nom::IResult<&str, Vec<AttachedSignaturePrefix>> {
+fn signatures(s: &[u8]) -> nom::IResult<&[u8], Vec<AttachedSignaturePrefix>> {
     let (rest, sc) = sig_count(s)?;
     count(attached_signature, sc as usize)(rest)
 }
 
-pub fn signed_message(s: &str) -> nom::IResult<&str, SignedEventMessage> {
+pub fn signed_message(s: &[u8]) -> nom::IResult<&[u8], SignedEventMessage> {
     let (rest, t) = nom::sequence::tuple((message, signatures))(s)?;
     Ok((rest, SignedEventMessage::new(&t.0, t.1)))
 }
 
-pub fn signed_event_stream(s: &str) -> nom::IResult<&str, Vec<SignedEventMessage>> {
+pub fn signed_event_stream(s: &[u8]) -> nom::IResult<&[u8], Vec<SignedEventMessage>> {
     many0(signed_message)(s)
 }
 
-pub fn signed_event_stream_validate(s: &str) -> nom::IResult<&str, IdentifierState> {
+pub fn signed_event_stream_validate(s: &[u8]) -> nom::IResult<&[u8], IdentifierState> {
     let (rest, id) = fold_many1(
         signed_message,
         Ok(IdentifierState::default()),
@@ -125,29 +125,29 @@ fn test_sigs() {
         derivation::{attached_signature_code::AttachedSignatureCode, self_signing::SelfSigning},
         prefix::AttachedSignaturePrefix,
     };
-    assert_eq!(sig_count("-AAA"), Ok(("", 0u16)));
-    assert_eq!(sig_count("-ABA"), Ok(("", 64u16)));
+    assert_eq!(sig_count("-AAA".as_bytes()), Ok(("".as_bytes(), 0u16)));
+    assert_eq!(sig_count("-ABA".as_bytes()), Ok(("".as_bytes(), 64u16)));
     assert_eq!(
-        sig_count("-AABextra data and stuff"),
-        Ok(("extra data and stuff", 1u16))
+        sig_count("-AABextra data and stuff".as_bytes(),),
+        Ok(("extra data and stuff".as_bytes(), 1u16))
     );
 
     assert_eq!(
-        signatures("-AABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
-        Ok(("", vec![AttachedSignaturePrefix::new(SelfSigning::Ed25519Sha512, vec![0u8; 64], 0)]))
+        signatures("-AABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".as_bytes()),
+        Ok(("".as_bytes(), vec![AttachedSignaturePrefix::new(SelfSigning::Ed25519Sha512, vec![0u8; 64], 0)]))
     );
 
     assert_eq!(
-        signatures("-AACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0AACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAextra data"),
-        Ok(("extra data", vec![
+        signatures("-AACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0AACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAextra data".as_bytes()),
+        Ok(("extra data".as_bytes(), vec![
             AttachedSignaturePrefix::new(SelfSigning::Ed25519Sha512, vec![0u8; 64], 0),
             AttachedSignaturePrefix::new(SelfSigning::Ed448, vec![0u8; 114], 2)
         ]))
     );
 
     assert_eq!(
-        signatures("-AACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0AACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
-        Ok(("", vec![
+        signatures("-AACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0AACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".as_bytes()),
+        Ok(("".as_bytes(), vec![
             AttachedSignaturePrefix::new(SelfSigning::Ed25519Sha512, vec![0u8; 64], 0),
             AttachedSignaturePrefix::new(SelfSigning::Ed448, vec![0u8; 114], 2)
         ]))
@@ -156,14 +156,14 @@ fn test_sigs() {
 
 #[test]
 fn test_event() {
-    let stream = r#"{"vs":"KERI10JSON000159_","pre":"ECui-E44CqN2U7uffCikRCp_YKLkPrA4jsTZ_A0XRLzc","sn":"0","ilk":"icp","sith":"2","keys":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA","DVcuJOOJF1IE8svqEtrSuyQjGTd2HhfAkt9y2QkUtFJI","DT1iAhBWCkvChxNWsby2J0pJyxBIxbAtbLA0Ljx-Grh8"],"nxt":"Evhf3437ZRRnVhT0zOxo_rBX_GxpGoAnLuzrVlDK8ZdM","toad":"0","wits":[],"cnfg":[]}extra data"#;
+    let stream = r#"{"vs":"KERI10JSON000159_","pre":"ECui-E44CqN2U7uffCikRCp_YKLkPrA4jsTZ_A0XRLzc","sn":"0","ilk":"icp","sith":"2","keys":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA","DVcuJOOJF1IE8svqEtrSuyQjGTd2HhfAkt9y2QkUtFJI","DT1iAhBWCkvChxNWsby2J0pJyxBIxbAtbLA0Ljx-Grh8"],"nxt":"Evhf3437ZRRnVhT0zOxo_rBX_GxpGoAnLuzrVlDK8ZdM","toad":"0","wits":[],"cnfg":[]}extra data"#.as_bytes();
     assert!(message(stream).is_ok())
 }
 
 #[test]
 fn test_stream1() {
     // taken from KERIPY: tests/core/test_eventing.py#903
-    let stream = r#"{"vs":"KERI10JSON000159_","pre":"ECui-E44CqN2U7uffCikRCp_YKLkPrA4jsTZ_A0XRLzc","sn":"0","ilk":"icp","sith":"2","keys":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA","DVcuJOOJF1IE8svqEtrSuyQjGTd2HhfAkt9y2QkUtFJI","DT1iAhBWCkvChxNWsby2J0pJyxBIxbAtbLA0Ljx-Grh8"],"nxt":"Evhf3437ZRRnVhT0zOxo_rBX_GxpGoAnLuzrVlDK8ZdM","toad":"0","wits":[],"cnfg":[]}-AADAAJ66nrRaNjltE31FZ4mELVGUMc_XOqOAOXZQjZCEAvbeJQ8r3AnccIe1aepMwgoQUeFdIIQLeEDcH8veLdud_DQABTQYtYWKh3ScYij7MOZz3oA6ZXdIDLRrv0ObeSb4oc6LYrR1LfkICfXiYDnp90tAdvaJX5siCLjSD3vfEM9ADDAACQTgUl4zF6U8hfDy8wwUva-HCAiS8LQuP7elKAHqgS8qtqv5hEj3aTjwE91UtgAX2oCgaw98BCYSeT5AuY1SpDA"#;
+    let stream = r#"{"vs":"KERI10JSON000159_","pre":"ECui-E44CqN2U7uffCikRCp_YKLkPrA4jsTZ_A0XRLzc","sn":"0","ilk":"icp","sith":"2","keys":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA","DVcuJOOJF1IE8svqEtrSuyQjGTd2HhfAkt9y2QkUtFJI","DT1iAhBWCkvChxNWsby2J0pJyxBIxbAtbLA0Ljx-Grh8"],"nxt":"Evhf3437ZRRnVhT0zOxo_rBX_GxpGoAnLuzrVlDK8ZdM","toad":"0","wits":[],"cnfg":[]}-AADAAJ66nrRaNjltE31FZ4mELVGUMc_XOqOAOXZQjZCEAvbeJQ8r3AnccIe1aepMwgoQUeFdIIQLeEDcH8veLdud_DQABTQYtYWKh3ScYij7MOZz3oA6ZXdIDLRrv0ObeSb4oc6LYrR1LfkICfXiYDnp90tAdvaJX5siCLjSD3vfEM9ADDAACQTgUl4zF6U8hfDy8wwUva-HCAiS8LQuP7elKAHqgS8qtqv5hEj3aTjwE91UtgAX2oCgaw98BCYSeT5AuY1SpDA"#.as_bytes();
 
     let event = signed_message(stream).unwrap().1;
     assert_eq!(
@@ -179,7 +179,7 @@ fn test_stream1() {
 #[test]
 fn test_stream2() {
     // generated by KERIOX
-    let stream = r#"{"vs":"KERI10JSON00012a_","pre":"E4_CHZxqydVAvJEI7beqk3TZwUR92nQydi1nI8UqUTxk","sn":"0","ilk":"icp","sith":"1","keys":["DLfozZ0uGvLED22X3K8lX6ciwhl02jdjt1DQ_EHnJro0","C6KROFI5gWRXhAiIMiHLCDa-Oj09kmVMr2btCE96k_3g"],"nxt":"E99mhvP0pLkGtxymQkspRqcdoIFOqdigCf_F3rpg7rfk","toad":"0","wits":[],"cnfg":[]}-AABAAlxZyoxbADu-x9Ho6EC7valjC4bNn7muWvqC_u0EBd1P9xIeOSxmcYdhyvBg1-o-25ebv66Q3Td5bZ730wqLjBA"#;
+    let stream = r#"{"vs":"KERI10JSON00012a_","pre":"E4_CHZxqydVAvJEI7beqk3TZwUR92nQydi1nI8UqUTxk","sn":"0","ilk":"icp","sith":"1","keys":["DLfozZ0uGvLED22X3K8lX6ciwhl02jdjt1DQ_EHnJro0","C6KROFI5gWRXhAiIMiHLCDa-Oj09kmVMr2btCE96k_3g"],"nxt":"E99mhvP0pLkGtxymQkspRqcdoIFOqdigCf_F3rpg7rfk","toad":"0","wits":[],"cnfg":[]}-AABAAlxZyoxbADu-x9Ho6EC7valjC4bNn7muWvqC_u0EBd1P9xIeOSxmcYdhyvBg1-o-25ebv66Q3Td5bZ730wqLjBA"#.as_bytes();
 
     assert!(signed_message(stream).is_ok());
     assert!(signed_event_stream(stream).is_ok());
@@ -189,7 +189,7 @@ fn test_stream2() {
 #[test]
 fn test_stream3() {
     // should fail to verify with incorrect signature
-    let stream = r#"{"vs":"KERI10JSON00012a_","pre":"E4_CHZxqydVAvJEI7beqk3TZwUR92nQydi1nI8UqUTxk","sn":"0","ilk":"icp","sith":"1","keys":["DLfozZ0uGvLED22X3K8lX6ciwhl02jdjt1DQ_EHnJro0","C6KROFI5gWRXhAiIMiHLCDa-Oj09kmVMr2btCE96k_3g"],"nxt":"E99mhvP0pLkGtxymQkspRqcdoIFOqdigCf_F3rpg7rfk","toad":"0","wits":[],"cnfg":[]}-AABAAlxZyoxbADu-x9Ho6EC7valjC4bNn7muWvqC_uAEBd1P9xIeOSxmcYdhyvBg1-o-25ebv66Q3Td5bZ730wqLjBA"#;
+    let stream = r#"{"vs":"KERI10JSON00012a_","pre":"E4_CHZxqydVAvJEI7beqk3TZwUR92nQydi1nI8UqUTxk","sn":"0","ilk":"icp","sith":"1","keys":["DLfozZ0uGvLED22X3K8lX6ciwhl02jdjt1DQ_EHnJro0","C6KROFI5gWRXhAiIMiHLCDa-Oj09kmVMr2btCE96k_3g"],"nxt":"E99mhvP0pLkGtxymQkspRqcdoIFOqdigCf_F3rpg7rfk","toad":"0","wits":[],"cnfg":[]}-AABAAlxZyoxbADu-x9Ho6EC7valjC4bNn7muWvqC_uAEBd1P9xIeOSxmcYdhyvBg1-o-25ebv66Q3Td5bZ730wqLjBA"#.as_bytes();
 
     assert!(signed_message(stream).is_ok());
     assert!(signed_event_stream(stream).is_ok());
@@ -198,7 +198,7 @@ fn test_stream3() {
 
 #[test]
 fn test_sed_extraction() {
-    let stream = r#"{"vs":"KERI10JSON000159_","pre":"ECui-E44CqN2U7uffCikRCp_YKLkPrA4jsTZ_A0XRLzc","sn":"0","ilk":"icp","sith":"2","keys":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA","DVcuJOOJF1IE8svqEtrSuyQjGTd2HhfAkt9y2QkUtFJI","DT1iAhBWCkvChxNWsby2J0pJyxBIxbAtbLA0Ljx-Grh8"],"nxt":"Evhf3437ZRRnVhT0zOxo_rBX_GxpGoAnLuzrVlDK8ZdM","toad":"0","wits":[],"cnfg":[]}"#;
+    let stream = r#"{"vs":"KERI10JSON000159_","pre":"ECui-E44CqN2U7uffCikRCp_YKLkPrA4jsTZ_A0XRLzc","sn":"0","ilk":"icp","sith":"2","keys":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA","DVcuJOOJF1IE8svqEtrSuyQjGTd2HhfAkt9y2QkUtFJI","DT1iAhBWCkvChxNWsby2J0pJyxBIxbAtbLA0Ljx-Grh8"],"nxt":"Evhf3437ZRRnVhT0zOxo_rBX_GxpGoAnLuzrVlDK8ZdM","toad":"0","wits":[],"cnfg":[]}"#.as_bytes();
 
     // sed transcoding is not required until arbitrary content events are used
     // assert!(sed(stream.as_bytes()).is_ok())

--- a/src/keri/mod.rs
+++ b/src/keri/mod.rs
@@ -163,7 +163,7 @@ impl Keri {
         Ok(ixn)
     }
 
-    pub fn process_events(&mut self, msg: &str) -> Result<String, Error> {
+    pub fn process_events(&mut self, msg: &[u8]) -> Result<String, Error> {
         let events = signed_event_stream(msg)
             .map_err(|_| Error::DeserializationError)?
             .1;

--- a/src/keri/test.rs
+++ b/src/keri/test.rs
@@ -22,7 +22,7 @@ fn test_direct_mode() -> Result<(), Error> {
     let mut msg_to_bob = alice.get_last_event();
 
     // Send it to bob.
-    let mut msg_to_alice = bob.process_events(&msg_to_bob)?;
+    let mut msg_to_alice = bob.process_events(&msg_to_bob.as_bytes())?;
     {
         // Check if bob's state of alice is the same as current alice state.
         let alice_state_in_bob = bob
@@ -33,7 +33,7 @@ fn test_direct_mode() -> Result<(), Error> {
     }
 
     // Send message from bob to alice and get alice's receipts.
-    msg_to_bob = alice.process_events(&msg_to_alice)?;
+    msg_to_bob = alice.process_events(&msg_to_alice.as_bytes())?;
 
     {
         // Check if alice's state of bob is the same as current bob state.
@@ -46,7 +46,7 @@ fn test_direct_mode() -> Result<(), Error> {
     }
 
     // Send it to bob.
-    bob.process_events(&msg_to_bob)?;
+    bob.process_events(&msg_to_bob.as_bytes())?;
     assert_eq!(bob.receipts[&0].len(), 1);
 
     // Rotation event.
@@ -56,7 +56,7 @@ fn test_direct_mode() -> Result<(), Error> {
 
     // Send rotation event to bob.
     msg_to_bob = alice.get_last_event();
-    msg_to_alice = bob.process_events(&msg_to_bob)?;
+    msg_to_alice = bob.process_events(&msg_to_bob.as_bytes())?;
     {
         // Check if bob's state of alice is the same as current alice state.
         let alice_state_in_bob = bob
@@ -67,7 +67,7 @@ fn test_direct_mode() -> Result<(), Error> {
     }
 
     // Send bob's receipt to alice.
-    alice.process_events(&msg_to_alice)?;
+    alice.process_events(&msg_to_alice.as_bytes())?;
     assert_eq!(alice.receipts.len(), 2);
     assert_eq!(alice.escrow_sigs.len(), 0);
 
@@ -78,7 +78,7 @@ fn test_direct_mode() -> Result<(), Error> {
 
     // Send interaction event to bob.
     msg_to_bob = alice.get_last_event();
-    msg_to_alice = bob.process_events(&msg_to_bob)?;
+    msg_to_alice = bob.process_events(&msg_to_bob.as_bytes())?;
 
     {
         // Check if bob's state of alice is the same as current alice state.
@@ -89,7 +89,7 @@ fn test_direct_mode() -> Result<(), Error> {
         assert_eq!(*alice_state_in_bob, alice.get_state());
     }
 
-    alice.process_events(&msg_to_alice)?;
+    alice.process_events(&msg_to_alice.as_bytes())?;
     assert_eq!(alice.receipts.len(), 3);
     assert_eq!(alice.escrow_sigs.len(), 0);
 


### PR DESCRIPTION
some message serializations are not valid utf-8 (cbor and msgpack), so the `parse` module should deal with `&[u8]` instead of `&str`