### PR TITLE
Feat/14/db

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 exp_ursa = []
+lmdb = ["rkv"]
+default = ["lmdb"]
 
 [dependencies]
 ursa = { version = "0.3", default-features = false, features = ["portable"]}
@@ -27,3 +29,6 @@ itoa = "0.4"
 ryu = "1.0"
 serde-transcode = "1.1"
 blake3 = { version = "0.3", default-features = false }
+chrono = "0.4"
+
+rkv = { version = "0.15", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 exp_ursa = []
-lmdb = ["rkv"]
+lmdb = ["rkv", "bincode"]
 default = ["lmdb"]
 
 [dependencies]
@@ -32,3 +32,4 @@ blake3 = { version = "0.3", default-features = false }
 chrono = "0.4"
 
 rkv = { version = "0.15", optional = true }
+bincode = { version = "1.3.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ license = "Apache-2.0"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-exp_ursa = []
 lmdb = ["rkv", "bincode"]
 default = ["lmdb"]
 
@@ -33,3 +32,6 @@ chrono = "0.4"
 
 rkv = { version = "0.15", optional = true }
 bincode = { version = "1.3.1", optional = true }
+
+[dev-dependencies]
+tempfile = "3.1"

--- a/src/database/lmdb.rs
+++ b/src/database/lmdb.rs
@@ -287,3 +287,17 @@ impl EventDatabase for LmdbEventDatabase {
         )
     }
 }
+
+#[test]
+fn basic() -> Result<(), StoreError> {
+    use super::test_db;
+    use std::fs;
+    use tempfile::Builder;
+
+    let root = Builder::new().prefix("test-db").tempdir().unwrap();
+    fs::create_dir_all(root.path()).unwrap();
+
+    let db = LmdbEventDatabase::new(root.path())?;
+
+    test_db(db)
+}

--- a/src/database/lmdb.rs
+++ b/src/database/lmdb.rs
@@ -1,0 +1,220 @@
+use super::EventDatabase;
+use crate::prefix::{AttachedSignaturePrefix, IdentifierPrefix, Prefix, SelfAddressingPrefix};
+use chrono::prelude::*;
+use rkv::{
+    backend::{BackendDatabase, BackendEnvironment, SafeModeDatabase, SafeModeEnvironment},
+    value::Type,
+    DataError, Manager, MultiStore, Rkv, SingleStore, StoreError, Value,
+};
+use std::{
+    str::FromStr,
+    sync::{Arc, RwLock},
+};
+
+pub struct LmdbEventDatabase {
+    events: SingleStore<SafeModeDatabase>,
+    datetime_stamps: SingleStore<SafeModeDatabase>,
+    signatures: MultiStore<SafeModeDatabase>,
+    receipts_nt: MultiStore<SafeModeDatabase>,
+    escrowed_receipts_nt: MultiStore<SafeModeDatabase>,
+    receipts_t: MultiStore<SafeModeDatabase>,
+    escrowed_receipts_t: MultiStore<SafeModeDatabase>,
+    key_event_logs: MultiStore<SafeModeDatabase>,
+    partially_signed_events: MultiStore<SafeModeDatabase>,
+    out_of_order_events: MultiStore<SafeModeDatabase>,
+    likely_duplicitous_events: MultiStore<SafeModeDatabase>,
+    duplicitous_events: MultiStore<SafeModeDatabase>,
+    env: Arc<RwLock<Rkv<SafeModeEnvironment>>>,
+}
+
+pub struct ContentIndex<'a>(&'a IdentifierPrefix, &'a SelfAddressingPrefix);
+pub struct SequenceIndex<'a>(&'a IdentifierPrefix, u64);
+
+// useful for using as an index type, but expensive
+// TODO: investigate using AsRef<[u8]>
+impl From<ContentIndex<'_>> for Vec<u8> {
+    fn from(ci: ContentIndex) -> Self {
+        [ci.0.to_str(), ".".into(), ci.1.to_str()]
+            .concat()
+            .into_bytes()
+    }
+}
+
+impl From<SequenceIndex<'_>> for Vec<u8> {
+    fn from(si: SequenceIndex) -> Self {
+        format!("{}.{:032}", si.0.to_str(), si.1).into_bytes()
+    }
+}
+
+impl<'a> EventDatabase<'a> for LmdbEventDatabase {
+    type Error = StoreError;
+
+    fn last_event_at_sn(
+        &self,
+        pref: &IdentifierPrefix,
+        sn: u64,
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        let lock = self.env.read()?;
+        let reader = lock.read()?;
+        let seq_index: Vec<u8> = SequenceIndex(pref, sn).into();
+
+        let dig = match self.key_event_logs.get(&reader, &seq_index)?.last() {
+            Some(v) => match v?.1 {
+                Value::Str(s) => SelfAddressingPrefix::from_str(s),
+                _ => {
+                    return Err(StoreError::DataError(DataError::UnexpectedType {
+                        expected: Type::Str,
+                        actual: Type::from_tag(0u8)?,
+                    }))
+                }
+            },
+            None => return Ok(None),
+        };
+
+        let dig_index: Vec<u8> = ContentIndex(pref, &dig).into();
+        let ret = match self.events.get(&reader, &dig_index)? {
+            Some(v) => match v {
+                Value::Blob(b) => Ok(Some(b.to_vec())),
+                _ => {
+                    return Err(StoreError::DataError(DataError::UnexpectedType {
+                        expected: Type::Str,
+                        actual: Type::from_tag(0u8)?,
+                    }))
+                }
+            },
+            None => return Ok(None),
+        };
+
+        ret
+    }
+
+    fn log_event(
+        &self,
+        pref: &IdentifierPrefix,
+        dig: &SelfAddressingPrefix,
+        raw: &[u8],
+        sigs: &[AttachedSignaturePrefix],
+    ) -> Result<(), Self::Error> {
+        let lock = self.env.read()?;
+        let mut writer = lock.write()?;
+        let key: Vec<u8> = ContentIndex(pref, dig).into();
+
+        // insert timestamp for event
+        self.datetime_stamps.put(
+            &mut writer,
+            &key,
+            &Value::Blob(Utc::now().to_rfc3339().as_bytes()),
+        )?;
+
+        // insert signatures for event
+        for sig in sigs.iter() {
+            self.signatures
+                .put(&mut writer, &key, &Value::Blob(sig.to_str().as_bytes()))?;
+        }
+
+        // insert event itself
+        self.events.put(&mut writer, &key, &Value::Blob(raw))?;
+
+        writer.commit()
+    }
+
+    fn finalise_event(
+        &self,
+        pref: &IdentifierPrefix,
+        sn: u64,
+        dig: &SelfAddressingPrefix,
+    ) -> Result<(), Self::Error> {
+        let lock = self.env.read()?;
+        let mut writer = lock.write()?;
+        let key: Vec<u8> = SequenceIndex(pref, sn).into();
+
+        self.key_event_logs
+            .put(&mut writer, &key, &Value::Str(&dig.to_str()))?;
+
+        writer.commit()
+    }
+
+    fn escrow_partially_signed_event(
+        &self,
+        pref: &IdentifierPrefix,
+        sn: u64,
+        dig: &SelfAddressingPrefix,
+    ) -> Result<(), Self::Error> {
+        let lock = self.env.read()?;
+        let mut writer = lock.write()?;
+        let key: Vec<u8> = SequenceIndex(pref, sn).into();
+
+        self.partially_signed_events
+            .put(&mut writer, &key, &Value::Str(&dig.to_str()))?;
+
+        writer.commit()
+    }
+
+    fn escrow_out_of_order_event(
+        &self,
+        pref: &IdentifierPrefix,
+        sn: u64,
+        dig: &SelfAddressingPrefix,
+    ) -> Result<(), Self::Error> {
+        let lock = self.env.read()?;
+        let mut writer = lock.write()?;
+        let key: Vec<u8> = SequenceIndex(pref, sn).into();
+
+        self.partially_signed_events
+            .put(&mut writer, &key, &Value::Str(&dig.to_str()))?;
+
+        writer.commit()
+    }
+
+    fn likely_duplicitous_event(
+        &self,
+        pref: &IdentifierPrefix,
+        sn: u64,
+        dig: &SelfAddressingPrefix,
+    ) -> Result<(), Self::Error> {
+        let lock = self.env.read()?;
+        let mut writer = lock.write()?;
+        let key: Vec<u8> = SequenceIndex(pref, sn).into();
+
+        self.likely_duplicitous_events
+            .put(&mut writer, &key, &Value::Str(&dig.to_str()))?;
+
+        writer.commit()
+    }
+
+    fn duplicitous_event(
+        &self,
+        pref: &IdentifierPrefix,
+        sn: u64,
+        dig: &SelfAddressingPrefix,
+    ) -> Result<(), Self::Error> {
+        let lock = self.env.read()?;
+        let mut writer = lock.write()?;
+        let key: Vec<u8> = SequenceIndex(pref, sn).into();
+
+        self.duplicitous_events
+            .put(&mut writer, &key, &Value::Str(&dig.to_str()))?;
+
+        writer.commit()
+    }
+
+    fn add_nt_receipt_for_event(
+        &self,
+        pref: &IdentifierPrefix,
+        dig: &SelfAddressingPrefix,
+        signer: &IdentifierPrefix,
+        sig: &AttachedSignaturePrefix,
+    ) -> Result<(), Self::Error> {
+        let lock = self.env.read()?;
+        let mut writer = lock.write()?;
+        let key: Vec<u8> = ContentIndex(pref, dig).into();
+
+        self.duplicitous_events.put(
+            &mut writer,
+            &key,
+            &Value::Str(&[signer.to_str(), sig.to_str()].concat()),
+        )?;
+
+        writer.commit()
+    }
+}

--- a/src/database/lmdb.rs
+++ b/src/database/lmdb.rs
@@ -127,41 +127,16 @@ impl EventDatabase for LmdbEventDatabase {
         };
 
         let dig_index: Vec<u8> = ContentIndex(pref, &dig).into();
-        let ret = match self.events.get(&reader, &dig_index)? {
+        match self.events.get(&reader, &dig_index)? {
             Some(v) => match v {
                 Value::Blob(b) => Ok(Some(b.to_vec())),
-                _ => {
-                    return Err(StoreError::DataError(DataError::UnexpectedType {
-                        expected: Type::Str,
-                        actual: Type::from_tag(0u8)?,
-                    }))
-                }
+                _ => Err(StoreError::DataError(DataError::UnexpectedType {
+                    expected: Type::Blob,
+                    actual: Type::from_tag(0u8)?,
+                })),
             },
-            None => return Ok(None),
-        };
-
-        ret
-    }
-
-    fn get_state_for_prefix(
-        &self,
-        pref: &IdentifierPrefix,
-    ) -> Result<Option<IdentifierState>, Self::Error> {
-        todo!()
-    }
-
-    fn get_children_of_prefix(
-        &self,
-        pref: &IdentifierPrefix,
-    ) -> Result<Option<Vec<IdentifierPrefix>>, Self::Error> {
-        todo!()
-    }
-
-    fn get_parent_of_prefix(
-        &self,
-        pref: &IdentifierPrefix,
-    ) -> Result<Option<IdentifierPrefix>, Self::Error> {
-        todo!()
+            None => Ok(None),
+        }
     }
 
     fn log_event(

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -1,0 +1,75 @@
+use crate::prefix::{AttachedSignaturePrefix, IdentifierPrefix, SelfAddressingPrefix};
+
+pub trait EventDatabase<'a> {
+    type Error;
+    /// Last Event At SN
+    ///
+    /// Returns the raw bytes of the last event inserted
+    /// for a given identifier at a given sequence number
+    /// (rotation events can supercede interaction events
+    /// with the same sn)
+    fn last_event_at_sn(&self, pref: &IdentifierPrefix, sn: u64) -> Option<&'a [u8]>;
+
+    /// Log Event
+    ///
+    /// Adds the raw event data to the database
+    /// Should also log the time
+    fn log_event(
+        &self,
+        raw: &[u8],
+        prefix: &IdentifierPrefix,
+        dig: &SelfAddressingPrefix,
+        sigs: &[AttachedSignaturePrefix],
+    ) -> Result<(), Self::Error>;
+
+    /// Commit Event
+    ///
+    /// Update associated logs for fully verified event
+    fn commit_event(
+        &self,
+        prefix: &IdentifierPrefix,
+        sn: u64,
+        dig: &SelfAddressingPrefix,
+    ) -> Result<(), Self::Error>;
+
+    /// Escrow Partially Signed Event
+    ///
+    /// Escrows an Event which does not have enough signatures
+    fn escrow_partially_signed_event(
+        &self,
+        pref: &IdentifierPrefix,
+        sn: u64,
+        dig: &SelfAddressingPrefix,
+    ) -> Result<(), Self::Error>;
+
+    /// Escrow Out of Order Event
+    ///
+    /// Escrows an Event which has arrived before previous events
+    fn escrow_out_of_order_event(
+        &self,
+        pref: &IdentifierPrefix,
+        sn: u64,
+        dig: &SelfAddressingPrefix,
+    ) -> Result<(), Self::Error>;
+
+    /// Likely Duplicitous Event
+    ///
+    /// Marks an event as being likely duplicitous
+    fn likely_duplicitous_event(
+        &self,
+        pref: &IdentifierPrefix,
+        sn: u64,
+        dig: &SelfAddressingPrefix,
+    ) -> Result<(), Self::Error>;
+
+    /// Add Receipt
+    ///
+    /// Associates a signature Sig made by Signer with the event referenced by Dig and Pref
+    fn add_receipt(
+        &self,
+        pref: &IdentifierPrefix,
+        dig: &SelfAddressingPrefix,
+        signer: &IdentifierPrefix,
+        sig: &AttachedSignaturePrefix,
+    ) -> Result<(), Self::Error>;
+}

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -1,7 +1,11 @@
-use crate::prefix::{AttachedSignaturePrefix, IdentifierPrefix, SelfAddressingPrefix};
+use crate::prefix::{AttachedSignaturePrefix, BasicPrefix, IdentifierPrefix, SelfAddressingPrefix};
 pub mod lmdb;
 
-pub trait EventDatabase<'a> {
+/// Event Database
+///
+/// An Abstract model of state for Key Events,
+/// Signatures and Receipts.
+pub trait EventDatabase {
     type Error;
     /// Last Event At SN
     ///
@@ -16,10 +20,36 @@ pub trait EventDatabase<'a> {
         sn: u64,
     ) -> Result<Option<Vec<u8>>, Self::Error>;
 
+    /// Get Keys for Prefix
+    ///
+    /// Returns the current signing keys associated with
+    /// the given Prefix
+    fn get_keys_for_prefix(
+        &self,
+        pref: &IdentifierPrefix,
+    ) -> Result<Option<Vec<BasicPrefix>>, Self::Error>;
+
+    /// Get Children of Prefix
+    ///
+    /// Returns the Identifiers delegated to by the
+    /// given Prefix
+    fn get_children_of_prefix(
+        &self,
+        pref: &IdentifierPrefix,
+    ) -> Result<Option<Vec<IdentifierPrefix>>, Self::Error>;
+
+    /// Get Parent of Prefix
+    ///
+    /// Returns the delegator for the given Prefix,
+    /// if there is one
+    fn get_parent_of_prefix(
+        &self,
+        pref: &IdentifierPrefix,
+    ) -> Result<Option<IdentifierPrefix>, Self::Error>;
+
     /// Log Event
     ///
-    /// Adds the raw event data to the database
-    /// Should also log the time
+    /// Adds the raw event data to the database and a timestamp
     fn log_event(
         &self,
         prefix: &IdentifierPrefix,
@@ -78,10 +108,21 @@ pub trait EventDatabase<'a> {
         dig: &SelfAddressingPrefix,
     ) -> Result<(), Self::Error>;
 
-    /// Add Receipt
+    /// Add Non-Transferrable Receipt
     ///
     /// Associates a signature Sig made by Signer with the event referenced by Dig and Pref
     fn add_nt_receipt_for_event(
+        &self,
+        pref: &IdentifierPrefix,
+        dig: &SelfAddressingPrefix,
+        signer: &IdentifierPrefix,
+        sig: &AttachedSignaturePrefix,
+    ) -> Result<(), Self::Error>;
+
+    /// Add Transferrable Receipt
+    ///
+    /// Associates a signature Sig made by Signer with the event referenced by Dig and Pref
+    fn add_t_receipt_for_event(
         &self,
         pref: &IdentifierPrefix,
         dig: &SelfAddressingPrefix,

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -2,6 +2,7 @@ use crate::{
     prefix::{AttachedSignaturePrefix, IdentifierPrefix, SelfAddressingPrefix},
     state::IdentifierState,
 };
+#[cfg(feature = "lmdb")]
 pub mod lmdb;
 
 /// Event Database

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -1,4 +1,7 @@
-use crate::prefix::{AttachedSignaturePrefix, BasicPrefix, IdentifierPrefix, SelfAddressingPrefix};
+use crate::{
+    prefix::{AttachedSignaturePrefix, IdentifierPrefix, SelfAddressingPrefix},
+    state::IdentifierState,
+};
 pub mod lmdb;
 
 /// Event Database
@@ -20,14 +23,14 @@ pub trait EventDatabase {
         sn: u64,
     ) -> Result<Option<Vec<u8>>, Self::Error>;
 
-    /// Get Keys for Prefix
+    /// Get State for Prefix
     ///
-    /// Returns the current signing keys associated with
+    /// Returns the current State associated with
     /// the given Prefix
-    fn get_keys_for_prefix(
+    fn get_state_for_prefix(
         &self,
         pref: &IdentifierPrefix,
-    ) -> Result<Option<Vec<BasicPrefix>>, Self::Error>;
+    ) -> Result<Option<IdentifierState>, Self::Error>;
 
     /// Get Children of Prefix
     ///

--- a/src/event_message/parse.rs
+++ b/src/event_message/parse.rs
@@ -22,7 +22,7 @@ fn cbor_message(s: &str) -> nom::IResult<&str, EventMessage> {
     }
 }
 
-fn message(s: &str) -> nom::IResult<&str, EventMessage> {
+pub fn message(s: &str) -> nom::IResult<&str, EventMessage> {
     alt((json_message, cbor_message))(s)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod database;
 pub mod derivation;
 pub mod error;
 pub mod event;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -31,7 +31,7 @@ impl IdentifierState {
     /// Apply
     ///
     /// validates and applies the semantic rules of the event to the event state
-    fn apply<T: EventSemantics>(self, event: &T) -> Result<Self, Error> {
+    pub fn apply<T: EventSemantics>(self, event: &T) -> Result<Self, Error> {
         event.apply_to(self)
     }
 


### PR DESCRIPTION
Provides a very basic DB trait and an implementation relying on LMDB. closes #22 and closes #41.
The trait is intended to represent the abstract state changes which are the potential outcomes of processing events (e.g. appending to the KEL, escrowing until receipts arrive, escrowing receipts etc), not the exact representation which the DB will use (no tables).

The `get_state_for_prefix` method might be better moved to an `EventProcessor` struct, which can implement event processing and consume the DB, in turn being consumed by the `Keri` struct.