### PR TITLE
parsing should give a reference to original event bytes

### DIFF
--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -186,20 +186,20 @@ pub(crate) fn test_db<D: EventDatabase>(db: D) -> Result<(), D::Error> {
     .map(|raw| raw.parse().unwrap())
     .collect();
 
-    let event = message(raw.as_bytes()).unwrap().1.event.event;
+    let message = message(raw.as_bytes()).unwrap().1.event;
     let dig = SelfAddressing::Blake3_256.derive(raw.as_bytes());
 
-    db.log_event(&event.prefix, &dig, raw.as_bytes(), &sigs)?;
-    db.finalise_event(&event.prefix, 0, &dig)?;
+    db.log_event(&message.event.prefix, &dig, raw.as_bytes(), &sigs)?;
+    db.finalise_event(&message.event.prefix, 0, &dig)?;
 
-    let written = db.last_event_at_sn(&event.prefix, 0)?;
+    let written = db.last_event_at_sn(&message.event.prefix, 0)?;
 
     assert_eq!(written, Some(raw.as_bytes().to_vec()));
 
-    let state = db.get_state_for_prefix(&event.prefix)?.unwrap();
+    let state = db.get_state_for_prefix(&message.event.prefix)?.unwrap();
 
-    assert_eq!(&state.prefix, &event.prefix);
-    assert!(match event.event_data {
+    assert_eq!(&state.prefix, &message.event.prefix);
+    assert!(match message.event.event_data {
         EventData::Icp(icp) => icp.key_config == state.current,
         _ => false,
     });

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -56,7 +56,7 @@ pub trait EventDatabase {
             let parsed = message(&raw).unwrap().1;
             // apply it to the state
             // TODO avoid .clone()
-            state = match state.clone().apply(&parsed) {
+            state = match state.clone().apply(&parsed.event) {
                 Ok(s) => s,
                 // will happen when a recovery has overridden some part of the KEL,
                 // stop processing here
@@ -186,7 +186,7 @@ pub(crate) fn test_db<D: EventDatabase>(db: D) -> Result<(), D::Error> {
     .map(|raw| raw.parse().unwrap())
     .collect();
 
-    let event = message(raw.as_bytes()).unwrap().1.event;
+    let event = message(raw.as_bytes()).unwrap().1.event.event;
     let dig = SelfAddressing::Blake3_256.derive(raw.as_bytes());
 
     db.log_event(&event.prefix, &dig, raw.as_bytes(), &sigs)?;

--- a/src/derivation/self_signing.rs
+++ b/src/derivation/self_signing.rs
@@ -1,5 +1,5 @@
 use super::DerivationCode;
-use crate::error::Error;
+use crate::{error::Error, prefix::SelfSigningPrefix};
 use core::str::FromStr;
 
 /// Self Signing Derivations
@@ -10,6 +10,12 @@ pub enum SelfSigning {
     Ed25519Sha512,
     ECDSAsecp256k1Sha256,
     Ed448,
+}
+
+impl SelfSigning {
+    pub fn derive(&self, sig: Vec<u8>) -> SelfSigningPrefix {
+        SelfSigningPrefix::new(*self, sig)
+    }
 }
 
 impl DerivationCode for SelfSigning {

--- a/src/event_message/mod.rs
+++ b/src/event_message/mod.rs
@@ -5,7 +5,7 @@ use crate::{
         event_data::{inception::InceptionEvent, EventData},
         Event,
     },
-    prefix::{AttachedSignaturePrefix, IdentifierPrefix, Prefix},
+    prefix::{AttachedSignaturePrefix, BasicPrefix, IdentifierPrefix, Prefix, SelfSigningPrefix},
     state::{EventSemantics, IdentifierState, Verifiable},
     util::dfs_serializer,
 };
@@ -35,6 +35,12 @@ pub struct EventMessage {
 pub struct SignedEventMessage {
     pub event_message: EventMessage,
     pub signatures: Vec<AttachedSignaturePrefix>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SignedNontransferableReciept {
+    pub body: EventMessage,
+    pub couplets: Vec<(BasicPrefix, SelfSigningPrefix)>,
 }
 
 impl EventMessage {

--- a/src/event_message/parse.rs
+++ b/src/event_message/parse.rs
@@ -6,24 +6,52 @@ use crate::{
 use nom::{branch::*, combinator::*, error::ErrorKind, multi::*, sequence::*};
 use serde_transcode::transcode;
 
-fn json_message(s: &[u8]) -> nom::IResult<&[u8], EventMessage> {
+pub struct DeserializedEvent<'a> {
+    pub event: EventMessage,
+    pub raw: &'a [u8],
+}
+
+pub struct DeserializedSignedEvent<'a> {
+    pub event: DeserializedEvent<'a>,
+    pub signatures: Vec<AttachedSignaturePrefix>,
+}
+
+impl From<DeserializedSignedEvent<'_>> for SignedEventMessage {
+    fn from(de: DeserializedSignedEvent) -> SignedEventMessage {
+        SignedEventMessage::new(&de.event.event, de.signatures)
+    }
+}
+
+fn json_message(s: &[u8]) -> nom::IResult<&[u8], DeserializedEvent> {
     let mut stream = serde_json::Deserializer::from_slice(s).into_iter::<EventMessage>();
     match stream.next() {
-        Some(Ok(event)) => Ok((&s[stream.byte_offset()..], event)),
+        Some(Ok(event)) => Ok((
+            &s[stream.byte_offset()..],
+            DeserializedEvent {
+                event: event,
+                raw: &s[..stream.byte_offset()],
+            },
+        )),
         _ => Err(nom::Err::Error((s, ErrorKind::IsNot))),
     }
 }
 
-fn cbor_message(s: &[u8]) -> nom::IResult<&[u8], EventMessage> {
+fn cbor_message(s: &[u8]) -> nom::IResult<&[u8], DeserializedEvent> {
     let mut stream = serde_cbor::Deserializer::from_slice(s).into_iter::<EventMessage>();
     match stream.next() {
-        Some(Ok(event)) => Ok((&s[stream.byte_offset()..], event)),
+        Some(Ok(event)) => Ok((
+            &s[stream.byte_offset()..],
+            DeserializedEvent {
+                event: event,
+                raw: &s[..stream.byte_offset()],
+            },
+        )),
         _ => Err(nom::Err::Error((s, ErrorKind::IsNot))),
     }
 }
 
-pub fn message(s: &[u8]) -> nom::IResult<&[u8], EventMessage> {
-    alt((json_message, cbor_message))(s)
+pub fn message(s: &[u8]) -> nom::IResult<&[u8], DeserializedEvent> {
+    alt((json_message, cbor_message))(s).map(|d| (d.0, d.1))
 }
 
 fn json_sed_block(s: &[u8]) -> Result<Vec<u8>, Error> {
@@ -96,12 +124,18 @@ fn signatures(s: &[u8]) -> nom::IResult<&[u8], Vec<AttachedSignaturePrefix>> {
     count(attached_signature, sc as usize)(rest)
 }
 
-pub fn signed_message(s: &[u8]) -> nom::IResult<&[u8], SignedEventMessage> {
+pub fn signed_message(s: &[u8]) -> nom::IResult<&[u8], DeserializedSignedEvent> {
     let (rest, t) = nom::sequence::tuple((message, signatures))(s)?;
-    Ok((rest, SignedEventMessage::new(&t.0, t.1)))
+    Ok((
+        rest,
+        DeserializedSignedEvent {
+            event: t.0,
+            signatures: t.1,
+        },
+    ))
 }
 
-pub fn signed_event_stream(s: &[u8]) -> nom::IResult<&[u8], Vec<SignedEventMessage>> {
+pub fn signed_event_stream(s: &[u8]) -> nom::IResult<&[u8], Vec<DeserializedSignedEvent>> {
     many0(signed_message)(s)
 }
 
@@ -111,7 +145,7 @@ pub fn signed_event_stream_validate(s: &[u8]) -> nom::IResult<&[u8], IdentifierS
         Ok(IdentifierState::default()),
         |acc, next| {
             Ok(acc?
-                .verify_and_apply(&next)
+                .verify_and_apply(&SignedEventMessage::from(next))
                 .map_err(|_| nom::Err::Error((s, ErrorKind::Verify)))?)
         },
     )(s)?;
@@ -121,10 +155,7 @@ pub fn signed_event_stream_validate(s: &[u8]) -> nom::IResult<&[u8], IdentifierS
 
 #[test]
 fn test_sigs() {
-    use crate::{
-        derivation::{attached_signature_code::AttachedSignatureCode, self_signing::SelfSigning},
-        prefix::AttachedSignaturePrefix,
-    };
+    use crate::{derivation::self_signing::SelfSigning, prefix::AttachedSignaturePrefix};
     assert_eq!(sig_count("-AAA".as_bytes()), Ok(("".as_bytes(), 0u16)));
     assert_eq!(sig_count("-ABA".as_bytes()), Ok(("".as_bytes(), 64u16)));
     assert_eq!(
@@ -156,8 +187,10 @@ fn test_sigs() {
 
 #[test]
 fn test_event() {
-    let stream = r#"{"vs":"KERI10JSON000159_","pre":"ECui-E44CqN2U7uffCikRCp_YKLkPrA4jsTZ_A0XRLzc","sn":"0","ilk":"icp","sith":"2","keys":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA","DVcuJOOJF1IE8svqEtrSuyQjGTd2HhfAkt9y2QkUtFJI","DT1iAhBWCkvChxNWsby2J0pJyxBIxbAtbLA0Ljx-Grh8"],"nxt":"Evhf3437ZRRnVhT0zOxo_rBX_GxpGoAnLuzrVlDK8ZdM","toad":"0","wits":[],"cnfg":[]}extra data"#.as_bytes();
-    assert!(message(stream).is_ok())
+    let stream = r#"{"vs":"KERI10JSON000159_","pre":"ECui-E44CqN2U7uffCikRCp_YKLkPrA4jsTZ_A0XRLzc","sn":"0","ilk":"icp","sith":"2","keys":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA","DVcuJOOJF1IE8svqEtrSuyQjGTd2HhfAkt9y2QkUtFJI","DT1iAhBWCkvChxNWsby2J0pJyxBIxbAtbLA0Ljx-Grh8"],"nxt":"Evhf3437ZRRnVhT0zOxo_rBX_GxpGoAnLuzrVlDK8ZdM","toad":"0","wits":[],"cnfg":[]}"#.as_bytes();
+    let event = message(stream);
+    assert!(event.is_ok());
+    assert_eq!(event.unwrap().1.raw, stream)
 }
 
 #[test]
@@ -165,14 +198,13 @@ fn test_stream1() {
     // taken from KERIPY: tests/core/test_eventing.py#903
     let stream = r#"{"vs":"KERI10JSON000159_","pre":"ECui-E44CqN2U7uffCikRCp_YKLkPrA4jsTZ_A0XRLzc","sn":"0","ilk":"icp","sith":"2","keys":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA","DVcuJOOJF1IE8svqEtrSuyQjGTd2HhfAkt9y2QkUtFJI","DT1iAhBWCkvChxNWsby2J0pJyxBIxbAtbLA0Ljx-Grh8"],"nxt":"Evhf3437ZRRnVhT0zOxo_rBX_GxpGoAnLuzrVlDK8ZdM","toad":"0","wits":[],"cnfg":[]}-AADAAJ66nrRaNjltE31FZ4mELVGUMc_XOqOAOXZQjZCEAvbeJQ8r3AnccIe1aepMwgoQUeFdIIQLeEDcH8veLdud_DQABTQYtYWKh3ScYij7MOZz3oA6ZXdIDLRrv0ObeSb4oc6LYrR1LfkICfXiYDnp90tAdvaJX5siCLjSD3vfEM9ADDAACQTgUl4zF6U8hfDy8wwUva-HCAiS8LQuP7elKAHqgS8qtqv5hEj3aTjwE91UtgAX2oCgaw98BCYSeT5AuY1SpDA"#.as_bytes();
 
-    let event = signed_message(stream).unwrap().1;
+    let signed_event = signed_message(stream).unwrap().1;
     assert_eq!(
-        event.event_message.serialize().unwrap().len(),
-        event.event_message.serialization_info.size
+        signed_event.event.raw.len(),
+        signed_event.event.event.serialization_info.size
     );
 
     assert!(signed_message(stream).is_ok());
-    assert!(signed_event_stream(stream).is_ok());
     assert!(signed_event_stream_validate(stream).is_ok())
 }
 
@@ -182,7 +214,6 @@ fn test_stream2() {
     let stream = r#"{"vs":"KERI10JSON00012a_","pre":"E4_CHZxqydVAvJEI7beqk3TZwUR92nQydi1nI8UqUTxk","sn":"0","ilk":"icp","sith":"1","keys":["DLfozZ0uGvLED22X3K8lX6ciwhl02jdjt1DQ_EHnJro0","C6KROFI5gWRXhAiIMiHLCDa-Oj09kmVMr2btCE96k_3g"],"nxt":"E99mhvP0pLkGtxymQkspRqcdoIFOqdigCf_F3rpg7rfk","toad":"0","wits":[],"cnfg":[]}-AABAAlxZyoxbADu-x9Ho6EC7valjC4bNn7muWvqC_u0EBd1P9xIeOSxmcYdhyvBg1-o-25ebv66Q3Td5bZ730wqLjBA"#.as_bytes();
 
     assert!(signed_message(stream).is_ok());
-    assert!(signed_event_stream(stream).is_ok());
     assert!(signed_event_stream_validate(stream).is_ok())
 }
 
@@ -192,7 +223,6 @@ fn test_stream3() {
     let stream = r#"{"vs":"KERI10JSON00012a_","pre":"E4_CHZxqydVAvJEI7beqk3TZwUR92nQydi1nI8UqUTxk","sn":"0","ilk":"icp","sith":"1","keys":["DLfozZ0uGvLED22X3K8lX6ciwhl02jdjt1DQ_EHnJro0","C6KROFI5gWRXhAiIMiHLCDa-Oj09kmVMr2btCE96k_3g"],"nxt":"E99mhvP0pLkGtxymQkspRqcdoIFOqdigCf_F3rpg7rfk","toad":"0","wits":[],"cnfg":[]}-AABAAlxZyoxbADu-x9Ho6EC7valjC4bNn7muWvqC_uAEBd1P9xIeOSxmcYdhyvBg1-o-25ebv66Q3Td5bZ730wqLjBA"#.as_bytes();
 
     assert!(signed_message(stream).is_ok());
-    assert!(signed_event_stream(stream).is_ok());
     assert!(!signed_event_stream_validate(stream).is_ok())
 }
 

--- a/src/keri/mod.rs
+++ b/src/keri/mod.rs
@@ -22,7 +22,7 @@ use crate::{
         sections::{nxt_commitment, InceptionWitnessConfig, KeyConfig},
         Event, EventMessage, SerializationFormats,
     },
-    event_message::parse::signed_event_stream,
+    event_message::parse::{signed_event_stream, Deserialized},
     event_message::SignedEventMessage,
     log::EventLog,
     prefix::AttachedSignaturePrefix,
@@ -153,40 +153,49 @@ impl Keri {
             .1;
         let mut response: Vec<SignedEventMessage> = vec![];
         for dev in events {
-            let ev: SignedEventMessage = dev.into();
-            match ev.event_message.event.event_data {
-                EventData::Vrc(ref rct) => {
-                    let prefix_str = rct.validator_location_seal.prefix.to_str();
-                    let validator = self.other_instances.get(&prefix_str).unwrap().clone();
+            match dev {
+                Deserialized::Event(e) => {
+                    let ev: SignedEventMessage = e.into();
+                    match ev.event_message.event.event_data {
+                        EventData::Icp(_) => {
+                            let ev_prefix = ev.event_message.event.prefix.to_str();
+                            let state = IdentifierState::default().verify_and_apply(&ev)?;
 
-                    self.process_receipt(validator, ev).unwrap();
-                }
-                EventData::Icp(_) => {
-                    let ev_prefix = ev.event_message.event.prefix.to_str();
-                    let state = IdentifierState::default().verify_and_apply(&ev)?;
+                            if !self.other_instances.contains_key(&ev_prefix) {
+                                if let Some(icp) = self.kel.get_last() {
+                                    response.push(icp);
+                                }
+                            }
+                            self.other_instances.insert(ev_prefix.clone(), state);
+                            let rct = self.make_rct(ev.event_message)?;
+                            response.push(rct);
+                        }
+                        _ => {
+                            let prefix_str = ev.event_message.event.prefix.to_str();
 
-                    if !self.other_instances.contains_key(&ev_prefix) {
-                        if let Some(icp) = self.kel.get_last() {
-                            response.push(icp);
+                            let state = self
+                                .other_instances
+                                .remove(&prefix_str)
+                                .unwrap_or(IdentifierState::default());
+                            self.other_instances
+                                .insert(prefix_str.clone(), state.verify_and_apply(&ev)?);
+
+                            let rct = self.make_rct(ev.event_message)?;
+                            response.push(rct);
                         }
                     }
-                    self.other_instances.insert(ev_prefix.clone(), state);
-                    let rct = self.make_rct(ev.event_message)?;
-                    response.push(rct);
                 }
-                _ => {
-                    let prefix_str = ev.event_message.event.prefix.to_str();
+                Deserialized::Vrc(r) => match r.event_message.event.event_data {
+                    EventData::Vrc(ref rct) => {
+                        let prefix_str = rct.validator_location_seal.prefix.to_str();
+                        let validator = self.other_instances.get(&prefix_str).unwrap().clone();
 
-                    let state = self
-                        .other_instances
-                        .remove(&prefix_str)
-                        .unwrap_or(IdentifierState::default());
-                    self.other_instances
-                        .insert(prefix_str.clone(), state.verify_and_apply(&ev)?);
-
-                    let rct = self.make_rct(ev.event_message)?;
-                    response.push(rct);
-                }
+                        self.process_receipt(validator, r).unwrap();
+                    }
+                    // NOTE should never happen
+                    _ => Err(Error::SemanticError("Incorrect Receipt Structure".into()))?,
+                },
+                Deserialized::Rct(_) => todo!(),
             }
         }
         let str_res = response

--- a/src/keri/mod.rs
+++ b/src/keri/mod.rs
@@ -46,7 +46,6 @@ impl Keri {
     pub fn new() -> Result<Keri, Error> {
         let key_manager = CryptoBox::new()?;
 
-
         let icp = InceptionEvent::new(
             KeyConfig::new(
                 vec![Basic::Ed25519.derive(key_manager.public_key())],
@@ -153,7 +152,8 @@ impl Keri {
             .map_err(|_| Error::DeserializationError)?
             .1;
         let mut response: Vec<SignedEventMessage> = vec![];
-        for ev in events {
+        for dev in events {
+            let ev: SignedEventMessage = dev.into();
             match ev.event_message.event.event_data {
                 EventData::Vrc(ref rct) => {
                     let prefix_str = rct.validator_location_seal.prefix.to_str();


### PR DESCRIPTION
PR defines a new struct returned from parsing events which has a reference to the original event bytes. This avoids having to worry about reserialization not matching the original when the signatures are verified, and lets the original bytes be stored exactly as they were received. Also adds a new `Deserialized` enum which tags if the deserialised message is a receipt or event and allows for the unique signature structure of witness receipts to be parsed as well.