### PR TITLE
Delegation logic

### DIFF
--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -8,7 +8,6 @@ use ursa::CryptoError;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    
     #[error("Error during Serialization: {0}")]
     SerializationError(String),
 

--- a/src/event/event_data/delegated/mod.rs
+++ b/src/event/event_data/delegated/mod.rs
@@ -26,7 +26,10 @@ pub struct DelegatedRotationEvent {
 
 impl EventSemantics for DelegatedInceptionEvent {
     fn apply_to(&self, state: IdentifierState) -> Result<IdentifierState, Error> {
-        self.inception_data.apply_to(state)
+        Ok(IdentifierState {
+            delegator: Some(self.seal.prefix.clone()),
+            ..self.inception_data.apply_to(state)?
+        })
     }
 }
 impl EventSemantics for DelegatedRotationEvent {}

--- a/src/event/event_data/delegated/mod.rs
+++ b/src/event/event_data/delegated/mod.rs
@@ -19,8 +19,6 @@ pub struct DelegatedRotationEvent {
     #[serde(flatten)]
     pub rotation_data: RotationEvent,
 
-    pub perm: Vec<String>,
-
     pub seal: LocationSeal,
 }
 

--- a/src/event/event_data/delegated/mod.rs
+++ b/src/event/event_data/delegated/mod.rs
@@ -37,7 +37,7 @@ impl DelegatedInceptionEvent {
         format: SerializationFormats,
     ) -> Result<EventMessage, Error> {
         let prefix = IdentifierPrefix::SelfAddressing(derivation.derive(
-            &EventMessage::get_inception_data(&EventData::Dip(self.clone()), derivation, format)?,
+            &EventMessage::get_delegated_inception_data(&self, derivation, format)?,
         ));
         EventMessage::new(
             Event {

--- a/src/event/event_data/delegated/mod.rs
+++ b/src/event/event_data/delegated/mod.rs
@@ -30,4 +30,12 @@ impl EventSemantics for DelegatedInceptionEvent {
         })
     }
 }
-impl EventSemantics for DelegatedRotationEvent {}
+impl EventSemantics for DelegatedRotationEvent {
+    fn apply_to(&self, state: IdentifierState) -> Result<IdentifierState, Error> {
+        if state.delegator == Some(self.seal.prefix.clone()) {
+            self.rotation_data.apply_to(state)
+        } else {
+            Err(Error::SemanticError("Wrong delegator".into()))
+        }
+    }
+}

--- a/src/event/event_data/delegated/mod.rs
+++ b/src/event/event_data/delegated/mod.rs
@@ -1,7 +1,10 @@
-use super::super::sections::seal::LocationSeal;
+use super::{super::sections::seal::LocationSeal, EventData};
 use super::{InceptionEvent, RotationEvent};
 use crate::{
+    derivation::self_addressing::SelfAddressing,
     error::Error,
+    event::{Event, EventMessage, SerializationFormats},
+    prefix::IdentifierPrefix,
     state::{EventSemantics, IdentifierState},
 };
 use serde::{Deserialize, Serialize};
@@ -20,6 +23,31 @@ pub struct DelegatedRotationEvent {
     pub rotation_data: RotationEvent,
 
     pub seal: LocationSeal,
+}
+
+impl DelegatedInceptionEvent {
+    /// Incept Self Addressing
+    ///
+    /// Takes the inception data and creates an EventMessage based on it, with
+    /// using the given format and deriving a Self Addressing Identifier with the
+    /// given derivation method
+    pub fn incept_self_addressing(
+        self,
+        derivation: SelfAddressing,
+        format: SerializationFormats,
+    ) -> Result<EventMessage, Error> {
+        let prefix = IdentifierPrefix::SelfAddressing(derivation.derive(
+            &EventMessage::get_inception_data(&EventData::Dip(self.clone()), derivation, format)?,
+        ));
+        EventMessage::new(
+            Event {
+                prefix,
+                sn: 0,
+                event_data: EventData::Dip(self),
+            },
+            format,
+        )
+    }
 }
 
 impl EventSemantics for DelegatedInceptionEvent {

--- a/src/event/event_data/delegated/mod.rs
+++ b/src/event/event_data/delegated/mod.rs
@@ -1,14 +1,15 @@
 use super::super::sections::seal::LocationSeal;
 use super::{InceptionEvent, RotationEvent};
-use crate::state::EventSemantics;
+use crate::{
+    error::Error,
+    state::{EventSemantics, IdentifierState},
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DelegatedInceptionEvent {
     #[serde(flatten)]
     pub inception_data: InceptionEvent,
-
-    pub perm: Vec<String>,
 
     pub seal: LocationSeal,
 }
@@ -23,5 +24,9 @@ pub struct DelegatedRotationEvent {
     pub seal: LocationSeal,
 }
 
-impl EventSemantics for DelegatedInceptionEvent {}
+impl EventSemantics for DelegatedInceptionEvent {
+    fn apply_to(&self, state: IdentifierState) -> Result<IdentifierState, Error> {
+        self.inception_data.apply_to(state)
+    }
+}
 impl EventSemantics for DelegatedRotationEvent {}

--- a/src/event/event_data/inception.rs
+++ b/src/event/event_data/inception.rs
@@ -51,7 +51,7 @@ impl InceptionEvent {
         format: SerializationFormats,
     ) -> Result<EventMessage, Error> {
         let prefix = IdentifierPrefix::SelfAddressing(derivation.derive(
-            &EventMessage::get_inception_data(&self, derivation, format)?,
+            &EventMessage::get_inception_data(&EventData::Icp(self.clone()), derivation, format)?,
         ));
 
         EventMessage::new(

--- a/src/event/event_data/inception.rs
+++ b/src/event/event_data/inception.rs
@@ -51,7 +51,7 @@ impl InceptionEvent {
         format: SerializationFormats,
     ) -> Result<EventMessage, Error> {
         let prefix = IdentifierPrefix::SelfAddressing(derivation.derive(
-            &EventMessage::get_inception_data(&EventData::Icp(self.clone()), derivation, format)?,
+            &EventMessage::get_inception_data(&self, derivation, format)?,
         ));
 
         EventMessage::new(

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -30,7 +30,7 @@ impl Event {
 impl EventSemantics for Event {
     fn apply_to(&self, state: IdentifierState) -> Result<IdentifierState, Error> {
         match self.event_data {
-            EventData::Icp(_) => {
+            EventData::Icp(_) | EventData::Dip(_) => {
                 // ICP events require the state to be uninitialized
                 if state.prefix != IdentifierPrefix::default() {
                     return Err(Error::EventDuplicateError);

--- a/src/event_message/mod.rs
+++ b/src/event_message/mod.rs
@@ -185,6 +185,22 @@ impl EventSemantics for EventMessage {
                     ..state
                 })
             }
+            EventData::Drt(ref drt) => self.event.apply_to(state.clone()).and_then(|next_state| {
+                if drt
+                    .rotation_data
+                    .previous_event_hash
+                    .verify_binding(&state.last)
+                {
+                    Ok(IdentifierState {
+                        last: self.serialize()?,
+                        ..next_state
+                    })
+                } else {
+                    Err(Error::SemanticError(
+                        "Last event does not match previous event".to_string(),
+                    ))
+                }
+            }),
             _ => self.event.apply_to(state),
         }
     }

--- a/src/event_message/mod.rs
+++ b/src/event_message/mod.rs
@@ -178,6 +178,13 @@ impl EventSemantics for EventMessage {
                     }
                 })
             }
+            EventData::Dip(_) => {
+                // TODO verify binding?
+                self.event.apply_to(IdentifierState {
+                    last: self.serialize()?,
+                    ..state
+                })
+            }
             _ => self.event.apply_to(state),
         }
     }

--- a/src/event_message/mod.rs
+++ b/src/event_message/mod.rs
@@ -323,7 +323,7 @@ mod tests {
         assert_eq!(s0.current.threshold_key_digest, nxt);
         assert_eq!(s0.witnesses, vec![]);
         assert_eq!(s0.tally, 0);
-        assert_eq!(s0.delegated_keys, vec![]);
+        assert_eq!(s0.delegates, vec![]);
 
         Ok(())
     }
@@ -402,7 +402,7 @@ mod tests {
         assert_eq!(s0.current.threshold_key_digest, nexter_pref);
         assert_eq!(s0.witnesses, vec![]);
         assert_eq!(s0.tally, 0);
-        assert_eq!(s0.delegated_keys, vec![]);
+        assert_eq!(s0.delegates, vec![]);
 
         Ok(())
     }

--- a/src/event_message/parse.rs
+++ b/src/event_message/parse.rs
@@ -277,6 +277,12 @@ fn test_event() {
     let event = message(stream);
     assert!(event.is_ok());
     assert_eq!(event.unwrap().1.raw, stream);
+
+    // Delegated inception event.
+    let stream = r#"{"vs":"KERI10JSON000183_","pre":"Ek7M173EvQZ6kLjyorCwZK4XWwyNcSi6u7lz5-M6MyFE","sn":"0","ilk":"dip","sith":"1","keys":["DuK1x8ydpucu3480Jpd1XBfjnCwb3dZ3x5b1CJmuUphA"],"nxt":"EWWkjZkZDXF74O2bOQ4H5hu4nXDlKg2m4CBEBkUxibiU","toad":"0","wits":[],"cnfg":[],"seal":{"pre":"EXmV-FiCyD7U76DoXSQoHlG30hFLD2cuYWEQPp0mEu1U","sn":"1","ilk":"ixn","dig":"Ey-05xXgtfYvKyMGa-dladxUQyXv4JaPg-gaKuXLfceQ"}}"#.as_bytes();
+    let event = message(stream);
+    assert!(event.is_ok());
+    assert_eq!(event.unwrap().1.raw, stream);
 }
 
 #[test]

--- a/src/event_message/parse.rs
+++ b/src/event_message/parse.rs
@@ -283,6 +283,12 @@ fn test_event() {
     let event = message(stream);
     assert!(event.is_ok());
     assert_eq!(event.unwrap().1.raw, stream);
+
+    // Delegated rotation event.
+    let stream = r#"{"vs":"KERI10JSON0001c2_","pre":"Ek7M173EvQZ6kLjyorCwZK4XWwyNcSi6u7lz5-M6MyFE","sn":"1","ilk":"drt","dig":"EeBPcw30IVCylYANEGOg3V8f4nBYMspEpqNaq2Y8_knw","sith":"1","keys":["DTf6QZWoet154o9wvzeMuNhLQRr8JaAUeiC6wjB_4_08"],"nxt":"E8kyiXDfkE7idwWnAZQjHbUZMz-kd_yIMH0miptIFFPo","toad":"0","cuts":[],"adds":[],"data":[],"seal":{"pre":"EXmV-FiCyD7U76DoXSQoHlG30hFLD2cuYWEQPp0mEu1U","sn":"2","ilk":"ixn","dig":"Eews7edyNg7fa-bze0UcCSCG4vitUo6dB5DetsoZA2NU"}}"#.as_bytes();
+    let event = message(stream);
+    assert!(event.is_ok());
+    assert_eq!(event.unwrap().1.raw, stream);
 }
 
 #[test]

--- a/src/event_message/tests/test_utils.rs
+++ b/src/event_message/tests/test_utils.rs
@@ -193,7 +193,7 @@ fn test_update_identifier_state(
     assert_eq!(new_state.current.threshold_key_digest, next_dig);
     assert_eq!(new_state.witnesses, vec![]);
     assert_eq!(new_state.tally, 0);
-    assert_eq!(new_state.delegated_keys, vec![]);
+    assert_eq!(new_state.delegates, vec![]);
 
     let mut new_history = state_data.history_prefs.clone();
     // If event_type is establishment event, append current prefix to prefixes

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -132,6 +132,7 @@ impl<D: EventDatabase> EventProcessor<D> {
                 self.db
                     .escrow_out_of_order_event(pref, sn, dig)
                     .map_err(|_| Error::StorageError)?;
+                return Err(Error::EventOutOfOrderError);
             }
             Some(del_event) => {
                 // Deserialize event.

--- a/src/processor/tests.rs
+++ b/src/processor/tests.rs
@@ -199,5 +199,26 @@ fn test_delegation() -> Result<(), Error> {
     );
     assert_eq!(child_state.delegator, Some(bobs_pref));
 
+    // Bobs interaction event with delegated event seal.
+    let bob_ixn = r#"{"vs":"KERI10JSON00010e_","pre":"EXmV-FiCyD7U76DoXSQoHlG30hFLD2cuYWEQPp0mEu1U","sn":"2","ilk":"ixn","dig":"Eews7edyNg7fa-bze0UcCSCG4vitUo6dB5DetsoZA2NU","data":[{"pre":"Ek7M173EvQZ6kLjyorCwZK4XWwyNcSi6u7lz5-M6MyFE","dig":"EeiCC5kb8Ms2-T3lnx83kwEPq_iJBBL0QC03ab559Dts"}]}-AABAA3V9qL1YINRBkSvkj-Q-NyMQoWpprrK05mrUYQNuc1EoPAt9pBa8quPorxhB-Q0_DVAd5PI6zH9Wn5j0R_eZQDw"#;
+    let msg = signed_message(bob_ixn.as_bytes()).unwrap().1;
+    event_processor.process(msg)?;
+
+    // Delegated rotation event.
+    let drt_raw = r#"{"vs":"KERI10JSON0001c2_","pre":"Ek7M173EvQZ6kLjyorCwZK4XWwyNcSi6u7lz5-M6MyFE","sn":"1","ilk":"drt","dig":"EeBPcw30IVCylYANEGOg3V8f4nBYMspEpqNaq2Y8_knw","sith":"1","keys":["DTf6QZWoet154o9wvzeMuNhLQRr8JaAUeiC6wjB_4_08"],"nxt":"E8kyiXDfkE7idwWnAZQjHbUZMz-kd_yIMH0miptIFFPo","toad":"0","cuts":[],"adds":[],"data":[],"seal":{"pre":"EXmV-FiCyD7U76DoXSQoHlG30hFLD2cuYWEQPp0mEu1U","sn":"2","ilk":"ixn","dig":"Eews7edyNg7fa-bze0UcCSCG4vitUo6dB5DetsoZA2NU"}}-AABAAXRILNpCj1-oLVbl4ZLSkNZTDDDudEVqk2nHxA--lNhacAI1P_5-uAjlr93cmy2WDXZA61ddtF7mI5SjRMnSqDA"#;
+
+    let msg = signed_message(drt_raw.as_bytes()).unwrap().1;
+
+    let child_state = event_processor.process(msg.clone())?.unwrap();
+    assert_eq!(child_state.sn, 1);
+    assert_eq!(child_state.prefix, child_prefix);
+    assert_eq!(
+        child_state.last,
+        match msg {
+            Deserialized::Event(e) => e.event.event.serialize()?,
+            _ => vec![],
+        }
+    );
+
     Ok(())
 }

--- a/src/processor/tests.rs
+++ b/src/processor/tests.rs
@@ -175,24 +175,33 @@ fn test_delegation() -> Result<(), Error> {
 
     // Bobs interaction event with delegated event seal.
     let bobs_ixn = r#"{"vs":"KERI10JSON00010e_","pre":"EXmV-FiCyD7U76DoXSQoHlG30hFLD2cuYWEQPp0mEu1U","sn":"1","ilk":"ixn","dig":"Ey-05xXgtfYvKyMGa-dladxUQyXv4JaPg-gaKuXLfceQ","data":[{"pre":"Ek7M173EvQZ6kLjyorCwZK4XWwyNcSi6u7lz5-M6MyFE","dig":"EeBPcw30IVCylYANEGOg3V8f4nBYMspEpqNaq2Y8_knw"}]}-AABAA8_fyED6L-y6d8GUg1nKCMtfhyChd_6_bpfAXv1nMC76lzpyaPBTm0O6geoO9kBuaaBCz3ojPUDAtktikVRFlCA"#;
-    let msg = signed_message(bobs_ixn.as_bytes()).unwrap().1;
-    event_processor.process(msg)?;
+    let delegating_msg = signed_message(bobs_ixn.as_bytes()).unwrap().1;
 
     let bobs_pref: IdentifierPrefix = "EXmV-FiCyD7U76DoXSQoHlG30hFLD2cuYWEQPp0mEu1U".parse()?;
 
     // Delegated inception event.
     let dip_raw = r#"{"vs":"KERI10JSON000183_","pre":"Ek7M173EvQZ6kLjyorCwZK4XWwyNcSi6u7lz5-M6MyFE","sn":"0","ilk":"dip","sith":"1","keys":["DuK1x8ydpucu3480Jpd1XBfjnCwb3dZ3x5b1CJmuUphA"],"nxt":"EWWkjZkZDXF74O2bOQ4H5hu4nXDlKg2m4CBEBkUxibiU","toad":"0","wits":[],"cnfg":[],"seal":{"pre":"EXmV-FiCyD7U76DoXSQoHlG30hFLD2cuYWEQPp0mEu1U","sn":"1","ilk":"ixn","dig":"Ey-05xXgtfYvKyMGa-dladxUQyXv4JaPg-gaKuXLfceQ"}}-AABAAMSF33ZiOLYH7Pg74MnMQjbfT_oq9wDeFy4ztfEWP0VagIKPqgYW_zrAkyJrZnQ-7-bfpekNtyRh3sN4doFseAg"#;
-
-    let msg = signed_message(dip_raw.as_bytes()).unwrap().1;
-
-    let child_state = event_processor.process(msg.clone())?.unwrap();
+    let delegated_msg = signed_message(dip_raw.as_bytes()).unwrap().1;
 
     let child_prefix: IdentifierPrefix = "Ek7M173EvQZ6kLjyorCwZK4XWwyNcSi6u7lz5-M6MyFE".parse()?;
+
+    // Process dip event before delegating ixn event.
+    let child_state = event_processor.process(delegated_msg.clone());
+    assert!(matches!(child_state, Err(Error::EventOutOfOrderError)));
+
+    // Check if processed dip is in kel.
+    let dip_from_db = event_processor.db.last_event_at_sn(&child_prefix, 0);
+    assert!(matches!(dip_from_db, Ok(None)));
+
+    event_processor.process(delegating_msg)?;
+
+    let child_state = event_processor.process(delegated_msg.clone())?.unwrap();
+
     assert_eq!(child_state.sn, 0);
     assert_eq!(child_state.prefix, child_prefix);
     assert_eq!(
         child_state.last,
-        match msg {
+        match delegated_msg {
             Deserialized::Event(e) => e.event.event.serialize()?,
             _ => vec![],
         }
@@ -201,20 +210,28 @@ fn test_delegation() -> Result<(), Error> {
 
     // Bobs interaction event with delegated event seal.
     let bob_ixn = r#"{"vs":"KERI10JSON00010e_","pre":"EXmV-FiCyD7U76DoXSQoHlG30hFLD2cuYWEQPp0mEu1U","sn":"2","ilk":"ixn","dig":"Eews7edyNg7fa-bze0UcCSCG4vitUo6dB5DetsoZA2NU","data":[{"pre":"Ek7M173EvQZ6kLjyorCwZK4XWwyNcSi6u7lz5-M6MyFE","dig":"EeiCC5kb8Ms2-T3lnx83kwEPq_iJBBL0QC03ab559Dts"}]}-AABAA3V9qL1YINRBkSvkj-Q-NyMQoWpprrK05mrUYQNuc1EoPAt9pBa8quPorxhB-Q0_DVAd5PI6zH9Wn5j0R_eZQDw"#;
-    let msg = signed_message(bob_ixn.as_bytes()).unwrap().1;
-    event_processor.process(msg)?;
+    let delegating_msg = signed_message(bob_ixn.as_bytes()).unwrap().1;
 
     // Delegated rotation event.
     let drt_raw = r#"{"vs":"KERI10JSON0001c2_","pre":"Ek7M173EvQZ6kLjyorCwZK4XWwyNcSi6u7lz5-M6MyFE","sn":"1","ilk":"drt","dig":"EeBPcw30IVCylYANEGOg3V8f4nBYMspEpqNaq2Y8_knw","sith":"1","keys":["DTf6QZWoet154o9wvzeMuNhLQRr8JaAUeiC6wjB_4_08"],"nxt":"E8kyiXDfkE7idwWnAZQjHbUZMz-kd_yIMH0miptIFFPo","toad":"0","cuts":[],"adds":[],"data":[],"seal":{"pre":"EXmV-FiCyD7U76DoXSQoHlG30hFLD2cuYWEQPp0mEu1U","sn":"2","ilk":"ixn","dig":"Eews7edyNg7fa-bze0UcCSCG4vitUo6dB5DetsoZA2NU"}}-AABAAXRILNpCj1-oLVbl4ZLSkNZTDDDudEVqk2nHxA--lNhacAI1P_5-uAjlr93cmy2WDXZA61ddtF7mI5SjRMnSqDA"#;
+    let delegated_msg = signed_message(drt_raw.as_bytes()).unwrap().1;
 
-    let msg = signed_message(drt_raw.as_bytes()).unwrap().1;
+    // Process drt event before delegating ixn event.
+    let child_state = event_processor.process(delegated_msg.clone());
+    assert!(matches!(child_state, Err(Error::EventOutOfOrderError)));
 
-    let child_state = event_processor.process(msg.clone())?.unwrap();
+    // Check if processed drt is in kel.
+    let drt_from_db = event_processor.db.last_event_at_sn(&child_prefix, 1);
+    assert!(matches!(drt_from_db, Ok(None)));
+
+    event_processor.process(delegating_msg)?;
+
+    let child_state = event_processor.process(delegated_msg.clone())?.unwrap();
     assert_eq!(child_state.sn, 1);
     assert_eq!(child_state.prefix, child_prefix);
     assert_eq!(
         child_state.last,
-        match msg {
+        match delegated_msg {
             Deserialized::Event(e) => e.event.event.serialize()?,
             _ => vec![],
         }

--- a/src/processor/tests.rs
+++ b/src/processor/tests.rs
@@ -197,6 +197,7 @@ fn test_delegation() -> Result<(), Error> {
             _ => vec![],
         }
     );
+    assert_eq!(child_state.delegator, Some(bobs_pref));
 
     Ok(())
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -18,6 +18,7 @@ pub struct IdentifierState {
     pub delegated_keys: Vec<IdentifierPrefix>,
     pub tally: u64,
     pub witnesses: Vec<BasicPrefix>,
+    pub delegator: Option<IdentifierPrefix>,
 }
 
 impl IdentifierState {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -15,7 +15,7 @@ pub struct IdentifierState {
     #[serde(skip)]
     pub last: Vec<u8>,
     pub current: KeyConfig,
-    pub delegated_keys: Vec<IdentifierPrefix>,
+    pub delegates: Vec<IdentifierPrefix>,
     pub tally: u64,
     pub witnesses: Vec<BasicPrefix>,
     pub delegator: Option<IdentifierPrefix>,


### PR DESCRIPTION
Related to #46 

Changes:

* logic of applying delegated inception and rotation events to `IdentifierState`,

* test of processing delegated events,

* test of delegated events deserialization.

It probably needs some refactor but seems to work fine.