### PR TITLE
Include sequence number in event seal

### DIFF
--- a/src/event/event_data/receipt.rs
+++ b/src/event/event_data/receipt.rs
@@ -34,12 +34,12 @@ pub struct ReceiptTransferable {
     #[serde(rename = "d")]
     pub receipted_event_digest: SelfAddressingPrefix,
 
-    /// Validator Location Seal
+    /// Validator Seal
     ///
     /// An Event Seal which indicates the latest establishment event of
     /// the Validator when the Receipt was made
     #[serde(rename = "a")]
-    pub validator_location_seal: EventSeal,
+    pub validator_seal: EventSeal,
 }
 
 impl EventSemantics for ReceiptTransferable {}

--- a/src/event/sections/seal.rs
+++ b/src/event/sections/seal.rs
@@ -28,6 +28,9 @@ pub struct EventSeal {
     #[serde(rename = "i")]
     pub prefix: IdentifierPrefix,
 
+    #[serde(rename = "s", with = "SerHex::<Compact>")]
+    pub sn: u64,
+
     #[serde(rename = "d")]
     pub event_digest: SelfAddressingPrefix,
 }
@@ -59,7 +62,7 @@ pub struct DelegatingEventSeal {
 #[test]
 fn test_seal_deserialization() {
     // Event seal
-    let seal_str = r#"{"i":"Ek7M173EvQZ6kLjyorCwZK4XWwyNcSi6u7lz5-M6MyFE","d":"EeBPcw30IVCylYANEGOg3V8f4nBYMspEpqNaq2Y8_knw"}"#;
+    let seal_str = r#"{"i":"Ek7M173EvQZ6kLjyorCwZK4XWwyNcSi6u7lz5-M6MyFE","s":"1","d":"EeBPcw30IVCylYANEGOg3V8f4nBYMspEpqNaq2Y8_knw"}"#;
     let seal: Seal = serde_json::from_str(seal_str).unwrap();
     assert!(matches!(seal, Seal::Event(_)));
     assert_eq!(serde_json::to_string(&seal).unwrap(), seal_str);

--- a/src/event_message/parse.rs
+++ b/src/event_message/parse.rs
@@ -299,10 +299,7 @@ fn test_event() {
     assert_eq!(event.unwrap().1.event.serialize().unwrap(), stream);
 
     // Rotation event.
-    let stream =  r#"{"v":"KERI10JSON00011c_","i":"EZAoTNZH3ULvaU6Z-i0d8JJR2nmwyYAfSVPzhzS6b5CM","s":"1","t":"rot","p":"EULvaU6JR2nmwyZ-i0d8JZAoTNZH3YAfSVPzhzS6b5CM","kt":"1","k":["DaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM"],"n":"EYAfSVPzhzZ-i0d8JZAoTNZH3ULvaU6JR2nmwyS6b5CM","wt":"1","wr":["DH3ULvaU6JR2nmwyYAfSVPzhzS6bZ-i0d8TNZJZAo5CM"],"wa":["DTNZH3ULvaU6JR2nmwyYAfSVPzhzS6bZ-i0d8JZAo5CM"],"a":[{"i":"EJJR2nmwyYAfSVPzhzS6b5CMZAoTNZH3ULvaU6Z-i0d8","d":"ELvaU6Z-i0d8JJR2nmwyYAZAoTNZH3UfSVPzhzS6b5CM"}]}"#.as_bytes();
-    // TODO Event seal doesn't contain sn, see issue #74 in dif/keri.
-    // Replace with the following line.
-    // let stream = r#"{"v":"KERI10JSON00011c_","i":"EZAoTNZH3ULvaU6Z-i0d8JJR2nmwyYAfSVPzhzS6b5CM","s":"1","t":"rot","p":"EULvaU6JR2nmwyZ-i0d8JZAoTNZH3YAfSVPzhzS6b5CM","kt":"1","k":["DaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM"],"n":"EYAfSVPzhzZ-i0d8JZAoTNZH3ULvaU6JR2nmwyS6b5CM","wt":"1","wr":["DH3ULvaU6JR2nmwyYAfSVPzhzS6bZ-i0d8TNZJZAo5CM"],"wa":["DTNZH3ULvaU6JR2nmwyYAfSVPzhzS6bZ-i0d8JZAo5CM"],"a":[{"i":"EJJR2nmwyYAfSVPzhzS6b5CMZAoTNZH3ULvaU6Z-i0d8","s":"0","d":"ELvaU6Z-i0d8JJR2nmwyYAZAoTNZH3UfSVPzhzS6b5CM"}]}"#.as_bytes();
+    let stream = r#"{"v":"KERI10JSON00011c_","i":"EZAoTNZH3ULvaU6Z-i0d8JJR2nmwyYAfSVPzhzS6b5CM","s":"1","t":"rot","p":"EULvaU6JR2nmwyZ-i0d8JZAoTNZH3YAfSVPzhzS6b5CM","kt":"1","k":["DaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM"],"n":"EYAfSVPzhzZ-i0d8JZAoTNZH3ULvaU6JR2nmwyS6b5CM","wt":"1","wr":["DH3ULvaU6JR2nmwyYAfSVPzhzS6bZ-i0d8TNZJZAo5CM"],"wa":["DTNZH3ULvaU6JR2nmwyYAfSVPzhzS6bZ-i0d8JZAo5CM"],"a":[{"i":"EJJR2nmwyYAfSVPzhzS6b5CMZAoTNZH3ULvaU6Z-i0d8","s":"0","d":"ELvaU6Z-i0d8JJR2nmwyYAZAoTNZH3UfSVPzhzS6b5CM"}]}"#.as_bytes();
     let event = message(stream);
     assert!(event.is_ok());
     assert_eq!(event.unwrap().1.event.serialize().unwrap(), stream);
@@ -314,10 +311,7 @@ fn test_event() {
     assert_eq!(event.unwrap().1.event.serialize().unwrap(), stream);
 
     // Interaction event with seal.
-    let stream = r#"{"v":"KERI10JSON00011c_","i":"EZAoTNZH3ULvaU6Z-i0d8JJR2nmwyYAfSVPzhzS6b5CM","s":"2","t":"ixn","p":"EULvaU6JR2nmwyZ-i0d8JZAoTNZH3YAfSVPzhzS6b5CM","a":[{"i":"EJJR2nmwyYAfSVPzhzS6b5CMZAoTNZH3ULvaU6Z-i0d8","d":"ELvaU6Z-i0d8JJR2nmwyYAZAoTNZH3UfSVPzhzS6b5CM"}]}"#.as_bytes();
-    // TODO Event seal doesn't contain sn, see issue #74 in dif/keri.
-    // Replace with the following line.
-    // let stream = r#"{"v":"KERI10JSON00011c_","i":"EZAoTNZH3ULvaU6Z-i0d8JJR2nmwyYAfSVPzhzS6b5CM","s":"2","t":"ixn","p":"EULvaU6JR2nmwyZ-i0d8JZAoTNZH3YAfSVPzhzS6b5CM","a":[{"i":"EJJR2nmwyYAfSVPzhzS6b5CMZAoTNZH3ULvaU6Z-i0d8","s":"1","d":"ELvaU6Z-i0d8JJR2nmwyYAZAoTNZH3UfSVPzhzS6b5CM"}]}"#.as_bytes();
+    let stream = r#"{"v":"KERI10JSON00011c_","i":"EZAoTNZH3ULvaU6Z-i0d8JJR2nmwyYAfSVPzhzS6b5CM","s":"2","t":"ixn","p":"EULvaU6JR2nmwyZ-i0d8JZAoTNZH3YAfSVPzhzS6b5CM","a":[{"i":"EJJR2nmwyYAfSVPzhzS6b5CMZAoTNZH3ULvaU6Z-i0d8","s":"1","d":"ELvaU6Z-i0d8JJR2nmwyYAZAoTNZH3UfSVPzhzS6b5CM"}]}"#.as_bytes();
     let event = message(stream);
     assert!(event.is_ok());
     assert_eq!(event.unwrap().1.event.serialize().unwrap(), stream);

--- a/src/keri/mod.rs
+++ b/src/keri/mod.rs
@@ -195,7 +195,7 @@ impl Keri {
                 },
                 Deserialized::Vrc(r) => match r.event_message.event.event_data {
                     EventData::Vrc(ref rct) => {
-                        let prefix_str = rct.validator_location_seal.prefix.to_str();
+                        let prefix_str = rct.validator_seal.prefix.to_str();
                         let validator = self.other_instances.get(&prefix_str).unwrap().clone();
 
                         self.process_receipt(validator, r).unwrap();
@@ -234,11 +234,11 @@ impl Keri {
                                     .derivation
                                     .derive(&event.event_message.serialize()?)
                             // seal pref is the pref of the validator
-                            && rct.validator_location_seal.prefix == validator.prefix
+                            && rct.validator_seal.prefix == validator.prefix
                 {
-                    if rct.validator_location_seal.event_digest
+                    if rct.validator_seal.event_digest
                         == rct
-                            .validator_location_seal
+                            .validator_seal
                             .event_digest
                             .derivation
                             .derive(&validator.last)
@@ -272,7 +272,7 @@ impl Keri {
             sn: event.event.sn,
             event_data: EventData::Vrc(ReceiptTransferable {
                 receipted_event_digest: SelfAddressing::Blake3_256.derive(&ser),
-                validator_location_seal: EventSeal {
+                validator_seal: EventSeal {
                     prefix: self.state.prefix.clone(),
                     sn: self.state.sn,
                     event_digest: SelfAddressing::Blake3_256.derive(&self.state.last),

--- a/src/keri/mod.rs
+++ b/src/keri/mod.rs
@@ -274,6 +274,7 @@ impl Keri {
                 receipted_event_digest: SelfAddressing::Blake3_256.derive(&ser),
                 validator_location_seal: EventSeal {
                     prefix: self.state.prefix.clone(),
+                    sn: self.state.sn,
                     event_digest: SelfAddressing::Blake3_256.derive(&self.state.last),
                 },
             }),

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -290,7 +290,7 @@ impl<D: EventDatabase> EventProcessor<D> {
                                 .escrow_t_receipt(
                                     &vrc.event_message.event.prefix,
                                     &r.receipted_event_digest,
-                                    &r.validator_location_seal.prefix,
+                                    &r.validator_seal.prefix,
                                     &sig,
                                 )
                                 .map_err(|_| Error::StorageError)?
@@ -300,8 +300,8 @@ impl<D: EventDatabase> EventProcessor<D> {
                     Some(event) => {
                         let keys = self
                             .get_keys_at_event(
-                                &r.validator_location_seal.prefix,
-                                &r.validator_location_seal.event_digest,
+                                &r.validator_seal.prefix,
+                                &r.validator_seal.event_digest,
                             )?
                             .ok_or(Error::SemanticError("No establishment Event found".into()))?;
                         if keys.verify(&event, &vrc.signatures)? {
@@ -310,7 +310,7 @@ impl<D: EventDatabase> EventProcessor<D> {
                                     .add_t_receipt_for_event(
                                         &vrc.event_message.event.prefix,
                                         &SelfAddressing::Blake3_256.derive(&event),
-                                        &r.validator_location_seal.prefix,
+                                        &r.validator_seal.prefix,
                                         &sig,
                                     )
                                     .map_err(|_| Error::StorageError);

--- a/src/processor/tests.rs
+++ b/src/processor/tests.rs
@@ -174,7 +174,7 @@ fn test_process_delegated() -> Result<(), Error> {
     // Delegated inception event.
     let dip_raw = r#"{"v":"KERI10JSON000165_","i":"Eillkf6Neo-Zmyn6Gg_8FS84RKWYgXblfoSXaOpttP7U","s":"0","t":"dip","kt":"1","k":["DSYuIQQrIi0N_a5gdzeXoqsNvo7PWHkn5ZrYO_ZmZdOA"],"n":"ESmikz_J7quPeKcfD_7d7jPDOfBsomZcg5I35vjMb69o","wt":"0","w":[],"c":[],"da":{"i":"DacyrOTuGEE1O5T0-JfoZxm_9tYRqKn5iKKzcXGe629M","s":"1","t":"ixn","p":"EnpsziyP_HrXY0GTDKn6jBCTq37akJ5W4nu3zGE9Nh5I"}}-AABAAtxbG6zfWOp73s5zxsKxXkrOi7h0CAbdYy5vBNmrG_oivi1uREgH7dUR-bpDO1lnMkcwg2ooDIIou_Ejs4bYpBA"#;
     let deserialized_dip = signed_message(dip_raw.as_bytes()).unwrap().1;
-    
+
     // Process dip event before delegating ixn event.
     let state = event_processor.process(deserialized_dip.clone());
     assert!(matches!(state, Err(Error::EventOutOfOrderError)));

--- a/src/processor/tests.rs
+++ b/src/processor/tests.rs
@@ -4,8 +4,8 @@ use crate::{
     database::EventDatabase,
     derivation::self_addressing::SelfAddressing,
     error::Error,
-    event::{self, sections::seal::LocationSeal},
-    event_message,
+    event::{event_data::EventData, sections::seal::LocationSeal},
+    event_message::parse::message,
 };
 use crate::{
     event_message::{
@@ -260,28 +260,37 @@ fn test_validate_seal() -> Result<(), Error> {
     let deserialized_icp = signed_message(delegator_icp_raw.as_bytes()).unwrap().1;
     event_processor.process(deserialized_icp.clone())?.unwrap();
 
-    let delegator_prefix: IdentifierPrefix =
-        "DcVUXDcB307nuuIlMGEUt9WZc4WF9W29IRvxDyVu6hyg".parse()?;
-    let delegator_last: Result<Vec<u8>, Error> = match deserialized_icp {
-        Deserialized::Event(e) => Ok(e.event.raw.to_vec()),
-        _ => Err(Error::SemanticError("bad deser".into()))?,
-    };
-    // Prepare delegating seal. Use sha3 to hash previous event.
-    let seal = LocationSeal {
-        prefix: delegator_prefix.clone(),
-        sn: 1,
-        ilk: "ixn".into(),
-        prior_digest: SelfAddressing::SHA3_256.derive(&delegator_last?),
-    };
-
-    // Delegating event uses Blake3 to hash previous event.
+    // Process delegating event.
     let delegating_event_raw = r#"{"v":"KERI10JSON000107_","i":"DcVUXDcB307nuuIlMGEUt9WZc4WF9W29IRvxDyVu6hyg","s":"1","t":"ixn","p":"E7rJVSh_MLTFcZ4v0urBxSJ103uR454Vo6St-wSCk_sI","a":[{"i":"EbuZO_Yr5Zt2Jvg0Sa96b2lDquGF3hHlhr7U7t3rLHvw","s":"0","d":"Eqid10S0HyiUI56hp2eBaS4pdnqvEnqV3p8f5DMfXX7w"}]}-AABAA1BOb5zF2PZ9x4GFpwVigVDTUAjpF1T3P23Z2uiwGej2J4EyoEvEW_WFxfVbyOLQW4eIWG2zNalOXy32sAL94BA"#;
     let deserialized_ixn = signed_message(delegating_event_raw.as_bytes()).unwrap().1;
-    event_processor.process(deserialized_ixn.clone())?.unwrap();
+    event_processor.process(deserialized_ixn.clone())?;
 
+    // Get seal from delegated inception event.
     let dip_raw = r#"{"v":"KERI10JSON000165_","i":"EbuZO_Yr5Zt2Jvg0Sa96b2lDquGF3hHlhr7U7t3rLHvw","s":"0","t":"dip","kt":"1","k":["DEQbpbOD29I6igCqlxNYVy-TsFa8kmPKLdYscL0lxsPE"],"n":"Ey6FhAzq0Ivj8E-NYjxkWrlj6mLFL67S6ADcsxMhX46s","wt":"0","w":[],"c":[],"da":{"i":"DcVUXDcB307nuuIlMGEUt9WZc4WF9W29IRvxDyVu6hyg","s":"1","t":"ixn","p":"HiQ3FpdUUTT8DyNJWIcN18OouhiA6SfjcajsBVDHVMeY"}}"#;
+    let deserialized_dip = message(dip_raw.as_bytes()).unwrap().1;
+    let seal = if let EventData::Dip(dip) = deserialized_dip.event.event.event_data {
+        dip.seal
+    } else {
+        LocationSeal::default()
+    };
 
-    event_processor.validate_seal(seal, dip_raw.as_bytes())?;
+    if let Deserialized::Event(ev) = deserialized_ixn.clone() {
+        if let EventData::Ixn(ixn) = ev.event.event.event.event_data {
+            assert_eq!(
+                ixn.previous_event_hash.derivation,
+                SelfAddressing::Blake3_256
+            );
+            assert_eq!(seal.prior_digest.derivation, SelfAddressing::SHA3_256);
+            assert_ne!(
+                ixn.previous_event_hash.derivation,
+                seal.prior_digest.derivation
+            );
+        }
+    };
+
+    assert!(event_processor
+        .validate_seal(seal, dip_raw.as_bytes())
+        .is_ok());
 
     Ok(())
 }

--- a/src/processor/tests.rs
+++ b/src/processor/tests.rs
@@ -165,28 +165,28 @@ fn test_process_delegated() -> Result<(), Error> {
         }
     };
 
-    let bobs_pref: IdentifierPrefix = "DacyrOTuGEE1O5T0-JfoZxm_9tYRqKn5iKKzcXGe629M".parse()?;
+    let bobs_pref: IdentifierPrefix = "DcIFrd3nstoRRo2LIDTgj5Pt4aZcYR20Mmp2m2eSd8KI".parse()?;
 
-    let bobs_icp = r#"{"v":"KERI10JSON0000e6_","i":"DacyrOTuGEE1O5T0-JfoZxm_9tYRqKn5iKKzcXGe629M","s":"0","t":"icp","kt":"1","k":["DacyrOTuGEE1O5T0-JfoZxm_9tYRqKn5iKKzcXGe629M"],"n":"ESyIFWDsYD1eCki8Xh8m3VTNvd_GcLa6weSjMkr1vGDM","wt":"0","w":[],"c":[]}-AABAAGMO_be5iMRqzULrWB9TP2BRuoxEMn4sxAxzrmcdMgYoRTHBxJpVeJ0R9NQQ_q_Kk_6CEpwt0fzHe4KFy1h1bBA"#;
+    let bobs_icp = r#"{"v":"KERI10JSON0000e6_","i":"DcIFrd3nstoRRo2LIDTgj5Pt4aZcYR20Mmp2m2eSd8KI","s":"0","t":"icp","kt":"1","k":["DcIFrd3nstoRRo2LIDTgj5Pt4aZcYR20Mmp2m2eSd8KI"],"n":"EIz9z6JYfIhnFKt5V8vZR_6aEG2R-LElRUlYR7tjcnhM","wt":"0","w":[],"c":[]}-AABAATYqdgjSbMFBX7T4KwSXHT_Um3DMfrnloNd59sDqYd7uB0Acvtazn0vjxhjHGP-Jg8gyMFn7284S0C4UMW3ZABw"#;
     let msg = signed_message(bobs_icp.as_bytes()).unwrap().1;
     event_processor.process(msg)?;
 
     // Delegated inception event.
-    let dip_raw = r#"{"v":"KERI10JSON000165_","i":"Eillkf6Neo-Zmyn6Gg_8FS84RKWYgXblfoSXaOpttP7U","s":"0","t":"dip","kt":"1","k":["DSYuIQQrIi0N_a5gdzeXoqsNvo7PWHkn5ZrYO_ZmZdOA"],"n":"ESmikz_J7quPeKcfD_7d7jPDOfBsomZcg5I35vjMb69o","wt":"0","w":[],"c":[],"da":{"i":"DacyrOTuGEE1O5T0-JfoZxm_9tYRqKn5iKKzcXGe629M","s":"1","t":"ixn","p":"EnpsziyP_HrXY0GTDKn6jBCTq37akJ5W4nu3zGE9Nh5I"}}-AABAAtxbG6zfWOp73s5zxsKxXkrOi7h0CAbdYy5vBNmrG_oivi1uREgH7dUR-bpDO1lnMkcwg2ooDIIou_Ejs4bYpBA"#;
+    let dip_raw = r#"{"v":"KERI10JSON000165_","i":"EUWbCTh_Q-GCNA5S93qjGFDehaxFROR6YyhQ7L7qJ6SI","s":"0","t":"dip","kt":"1","k":["DSW9x_sF6IVsUGhgtq5THbQ9OpJuUXQCQkuBWoYlSLFQ"],"n":"EUpF_MIgcEiT9RnGvwbz_TqHHctKRZEUiWWQTO1gIZlw","wt":"0","w":[],"c":[],"da":{"i":"DcIFrd3nstoRRo2LIDTgj5Pt4aZcYR20Mmp2m2eSd8KI","s":"1","t":"ixn","p":"ECK2OTG_AcrLf74_fknLxzt5lziU-crgYVgLbGp4jg2o"}}-AABAAHCLBmbnei-5gxBTGyXFJrF3DjTDQL15sjN5XbtJ07bQPoDCJw46XXx4TURCfhiAAhKTsskkqxCBOpYsMPpdTCw"#;
     let deserialized_dip = signed_message(dip_raw.as_bytes()).unwrap().1;
 
     // Process dip event before delegating ixn event.
     let state = event_processor.process(deserialized_dip.clone());
     assert!(matches!(state, Err(Error::EventOutOfOrderError)));
 
-    let child_prefix: IdentifierPrefix = "Eillkf6Neo-Zmyn6Gg_8FS84RKWYgXblfoSXaOpttP7U".parse()?;
+    let child_prefix: IdentifierPrefix = "EUWbCTh_Q-GCNA5S93qjGFDehaxFROR6YyhQ7L7qJ6SI".parse()?;
 
     // Check if processed dip is in kel.
     let dip_from_db = event_processor.db.last_event_at_sn(&child_prefix, 0);
     assert!(matches!(dip_from_db, Ok(None)));
 
     // Bob's ixn event with delegating event seal.
-    let bobs_ixn = r#"{"v":"KERI10JSON0000ff_","i":"DacyrOTuGEE1O5T0-JfoZxm_9tYRqKn5iKKzcXGe629M","s":"1","t":"ixn","p":"EnpsziyP_HrXY0GTDKn6jBCTq37akJ5W4nu3zGE9Nh5I","a":[{"i":"Eillkf6Neo-Zmyn6Gg_8FS84RKWYgXblfoSXaOpttP7U","d":"E-wVeNYeC-ft2R-eq1khZzBpJV4owTKLEMn5Qgb7ClzE"}]}-AABAAgaeWumWSWP9tfUpZYGP0W3DU2Wd20NheRMjSS7QcW8AeKMfgklLfqOLE_B5cF6G_GhcMtthDyK4oEffZ_Tm8Bg"#;
+    let bobs_ixn = r#"{"v":"KERI10JSON000107_","i":"DcIFrd3nstoRRo2LIDTgj5Pt4aZcYR20Mmp2m2eSd8KI","s":"1","t":"ixn","p":"ECK2OTG_AcrLf74_fknLxzt5lziU-crgYVgLbGp4jg2o","a":[{"i":"EUWbCTh_Q-GCNA5S93qjGFDehaxFROR6YyhQ7L7qJ6SI","s":"0","d":"EeOS5Xa51C-H9HCzuumjj4Rso8t0T8p1WaHg72tTrqhc"}]}-AABAArBypvPpBoKTTE_4zaOI4H9xxFxlsZ6Z8VLDGjxAZa_4ucRKAjNRTSe7nX5IgeiwIW6mek5J3_mUP27dRGMsNCw"#;
     let deserialized_ixn = signed_message(bobs_ixn.as_bytes()).unwrap().1;
     event_processor.process(deserialized_ixn.clone())?;
 
@@ -205,11 +205,11 @@ fn test_process_delegated() -> Result<(), Error> {
     assert_eq!(dip_from_db, Some(raw_parsed(deserialized_dip)?));
 
     // Bobs interaction event with delegated event seal.
-    let bob_ixn = r#"{"v":"KERI10JSON0000ff_","i":"DacyrOTuGEE1O5T0-JfoZxm_9tYRqKn5iKKzcXGe629M","s":"2","t":"ixn","p":"EDtl3GufXTAMhokeiHr0CM-N1X2clxGXhB9b9ci10Uug","a":[{"i":"Eillkf6Neo-Zmyn6Gg_8FS84RKWYgXblfoSXaOpttP7U","d":"E2hTgse4VcbsV_gJUEcTRx5DiZR-lgPrpYhtSGBBFt0E"}]}-AABAADpc3e49teDDinBTETcGpQWtP0QChXEmO_5x5T8KYcTu-hRBl-TvKIY0TK04D6kRBlQnteRu-RcX1uGNiQ1j6Dw"#;
+    let bob_ixn = r#"{"v":"KERI10JSON000107_","i":"DcIFrd3nstoRRo2LIDTgj5Pt4aZcYR20Mmp2m2eSd8KI","s":"2","t":"ixn","p":"EbEidxcOohgeM966TOonWlaOSRdK2Bsuxb0s0S04CX1g","a":[{"i":"EUWbCTh_Q-GCNA5S93qjGFDehaxFROR6YyhQ7L7qJ6SI","s":"1","d":"Edf4rT9DnCl58X1DEoWBsouXqPqO2ahI_oHjS1fltodQ"}]}-AABAAei17qaEa7VF6utjHay8L0TNWSPhw0Oj9Ho9zS0Mda2Oo5TkELA6Dd1jkTYwiTSecaX85-L56PC1-apEz2Bb3DA"#;
     let deserialized_ixn_drt = signed_message(bob_ixn.as_bytes()).unwrap().1;
 
     // Delegated rotation event.
-    let drt_raw = r#"{"v":"KERI10JSON0001a1_","i":"Eillkf6Neo-Zmyn6Gg_8FS84RKWYgXblfoSXaOpttP7U","s":"1","t":"drt","p":"E-wVeNYeC-ft2R-eq1khZzBpJV4owTKLEMn5Qgb7ClzE","kt":"1","k":["DWd0PYkfyJ3zZqh7nSi5ofwynBpGZocUpG6PA2bn21B0"],"n":"ETeDZvAk4Yj5n_rjSxRN7KYchOFTqqN-HcvMf86hU9gM","wt":"0","wr":[],"wa":[],"a":[],"da":{"i":"DacyrOTuGEE1O5T0-JfoZxm_9tYRqKn5iKKzcXGe629M","s":"2","t":"ixn","p":"EDtl3GufXTAMhokeiHr0CM-N1X2clxGXhB9b9ci10Uug"}}-AABAA4hOqk3e9YQd_caNU7fuVK2N5xpYeGv6hykwYfO51AaSoyNPpKjfx2nO_Y2Mt6i4llYUBkKLwaV1b4m7CrlCcAQ"#;
+    let drt_raw = r#"{"v":"KERI10JSON0001a1_","i":"EUWbCTh_Q-GCNA5S93qjGFDehaxFROR6YyhQ7L7qJ6SI","s":"1","t":"drt","p":"EeOS5Xa51C-H9HCzuumjj4Rso8t0T8p1WaHg72tTrqhc","kt":"1","k":["Dk0Wp-dkcPdbEkBGLvJGlrL5SAG0kBELx61B8e1bGi2o"],"n":"E_zHkOoJvV46tJI54ssGszaA351wem7_I_I3ZurpFbUA","wt":"0","wr":[],"wa":[],"a":[],"da":{"i":"DcIFrd3nstoRRo2LIDTgj5Pt4aZcYR20Mmp2m2eSd8KI","s":"2","t":"ixn","p":"EbEidxcOohgeM966TOonWlaOSRdK2Bsuxb0s0S04CX1g"}}-AABAAiqETyyvcU31_N7vgLzhe-tP4kMe0NneQaxFjYahq_IPK79k3nuLmeIAoA-FJTjGepHQ56CgUQUsTh0PLVD0mDA"#;
     let deserialized_drt = signed_message(drt_raw.as_bytes()).unwrap().1;
 
     // Process drt event before delegating ixn event.


### PR DESCRIPTION
Should resolve #56 
Changes:
* add sequence number field to `EventSeal`,
* update tests,
* update validator receipt processing to use `sn`,
* update delegating seal validation.