### PR TITLE
Get KERL

### DIFF
--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -71,6 +71,11 @@ pub trait EventDatabase {
         Ok(Some(state))
     }
 
+    /// Get KERL for Prefix
+    ///
+    /// Returns the current validated KERL for a given Prefix
+    fn get_kerl(&self, id: &IdentifierPrefix) -> Result<Option<Vec<u8>>, Self::Error>;
+
     /// Get Children of Prefix
     ///
     /// Returns the Identifiers delegated to by the
@@ -197,28 +202,39 @@ pub trait EventDatabase {
 
 pub(crate) fn test_db<D: EventDatabase>(db: D) -> Result<(), D::Error> {
     use crate::{
-        derivation::self_addressing::SelfAddressing, event::event_data::EventData,
-        event_message::parse::message,
+        derivation::self_addressing::SelfAddressing,
+        event_message::parse::{signed_message, Deserialized},
     };
 
-    let raw = r#"{"v":"KERI10JSON000144_","i":"E005TfcIFvrzhJFxoGqebPHvtanxEwcfJOAYcUtCmhk8","s":"0","t":"icp","kt":"1","k":["D5UzOMC5Knhi5eA-Cr8ASuD8lUcZMcLtAhIZ33W5Z4hs","DEbposribdTgsnCSQgmVN6VKoc4Vpc-hs9rbskXQ2O2M","D46n6npISQETk7eGYnwe5Jq7USmEsckHeJRu2YoTCXhU"],"n":"E2zBfVYkE2uaGR5DmMVBbWsIdBIZVu5Ml6joenraD5Ho","wt":"0","w":[],"c":[]}extra data"#;
-    let sigs: Vec<AttachedSignaturePrefix> = [
-        "AAKfgMIEsKlrXqUxUyw1Qq7gFrg9mNWcDAkQAXUW6Hppvt4NBdEbU_2Wy7Re0zp5zVvLjjq4hjPE5aXSeIlHh7Dg",
-        "AAIkKK8jI0l_tor7EaIM2B65aLn9e6Y3Igwa9OjDqbiyqXdL1yHxga7nhJY80Ct0zXGhm7hgLzgB6d86EqfXWLCQ",
-        "AABPCeqK_WXY64EZ8E91Y2trI6MfZT-f2NmtHCmmKhvt7AmehPcvQSvrcQbogdNEBr749AbVG7glVsV8WitVR2DQ",
-    ]
-    .iter()
-    .map(|raw| raw.parse().unwrap())
-    .collect();
+    // NOTE this is not actually a valid kel (sig indexes and prefix are wrong), just has the correct form
+    let signed = br#"{"v":"KERI10JSON000144_","i":"E005TfcIFvrzhJFxoGqebPHvtanxEwcfJOAYcUtCmhk8","s":"0","t":"icp","kt":"1","k":["D5UzOMC5Knhi5eA-Cr8ASuD8lUcZMcLtAhIZ33W5Z4hs","DEbposribdTgsnCSQgmVN6VKoc4Vpc-hs9rbskXQ2O2M","D46n6npISQETk7eGYnwe5Jq7USmEsckHeJRu2YoTCXhU"],"n":"E2zBfVYkE2uaGR5DmMVBbWsIdBIZVu5Ml6joenraD5Ho","wt":"0","w":[],"c":[]}-AADAAKfgMIEsKlrXqUxUyw1Qq7gFrg9mNWcDAkQAXUW6Hppvt4NBdEbU_2Wy7Re0zp5zVvLjjq4hjPE5aXSeIlHh7DgABIkKK8jI0l_tor7EaIM2B65aLn9e6Y3Igwa9OjDqbiyqXdL1yHxga7nhJY80Ct0zXGhm7hgLzgB6d86EqfXWLCQACBPCeqK_WXY64EZ8E91Y2trI6MfZT-f2NmtHCmmKhvt7AmehPcvQSvrcQbogdNEBr749AbVG7glVsV8WitVR2DQ"#;
+    let deser = match signed_message(signed).unwrap().1 {
+        Deserialized::Event(e) => e,
+        _ => panic!(),
+    };
 
-    let message = message(raw.as_bytes()).unwrap().1.event;
-    let dig = SelfAddressing::Blake3_256.derive(raw.as_bytes());
+    let dig = SelfAddressing::Blake3_256.derive(deser.event.raw);
 
-    db.log_event(&message.event.prefix, &dig, raw.as_bytes(), &sigs)?;
-    db.finalise_event(&message.event.prefix, 0, &dig)?;
+    db.log_event(
+        &deser.event.event.event.prefix,
+        &dig,
+        deser.event.raw,
+        &deser.signatures,
+    )?;
 
-    let written = db.last_event_at_sn(&message.event.prefix, 0)?;
+    db.finalise_event(&deser.event.event.event.prefix, 0, &dig)?;
 
-    assert_eq!(written, Some(raw.as_bytes().to_vec()));
+    let written = db.last_event_at_sn(&deser.event.event.event.prefix, 0)?;
+
+    assert_eq!(written, Some(deser.event.raw.to_vec()));
+
+    let kerl = db.get_kerl(&deser.event.event.event.prefix)?.unwrap();
+    let deser_2 = match signed_message(&kerl).unwrap().1 {
+        Deserialized::Event(e) => e,
+        _ => panic!(),
+    };
+
+    assert_eq!(deser, deser_2);
+
     Ok(())
 }

--- a/src/event/event_data/delegated/mod.rs
+++ b/src/event/event_data/delegated/mod.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct DelegatedInceptionEvent {
     #[serde(flatten)]
     pub inception_data: InceptionEvent,
@@ -18,7 +18,7 @@ pub struct DelegatedInceptionEvent {
     pub seal: LocationSeal,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct DelegatedRotationEvent {
     #[serde(flatten)]
     pub rotation_data: RotationEvent,

--- a/src/event/event_data/inception.rs
+++ b/src/event/event_data/inception.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 /// Inception Event
 ///
 /// Describes the inception (icp) event data,
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct InceptionEvent {
     #[serde(flatten)]
     pub key_config: KeyConfig,

--- a/src/event/event_data/interaction.rs
+++ b/src/event/event_data/interaction.rs
@@ -4,7 +4,7 @@ use crate::prefix::SelfAddressingPrefix;
 use crate::state::{EventSemantics, IdentifierState};
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct InteractionEvent {
     #[serde(rename = "p")]
     pub previous_event_hash: SelfAddressingPrefix,

--- a/src/event/event_data/mod.rs
+++ b/src/event/event_data/mod.rs
@@ -25,7 +25,7 @@ pub use self::{
 /// Event Data
 ///
 /// Event Data conveys the semantic content of a KERI event.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(tag = "t", rename_all = "lowercase")]
 pub enum EventData {
     Icp(InceptionEvent),

--- a/src/event/event_data/receipt.rs
+++ b/src/event/event_data/receipt.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 /// Mostly intended for use by Witnesses.
 /// NOTE: This receipt has a unique structure to it's appended
 /// signatures
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct ReceiptNonTransferable {
     /// Receipted Event Digest
     ///
@@ -26,7 +26,7 @@ impl EventSemantics for ReceiptNonTransferable {}
 /// Identifiers. Provides both the signatures and a commitment to
 /// the latest establishment event of the receipt creator.
 /// Mostly intended for use by Validators
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct ReceiptTransferable {
     /// Receipted Event Digest
     ///

--- a/src/event/event_data/rotation.rs
+++ b/src/event/event_data/rotation.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 /// Rotation Event
 ///
 /// Describes the rotation (rot) event data
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct RotationEvent {
     #[serde(rename = "p")]
     pub previous_event_hash: SelfAddressingPrefix,

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -9,7 +9,7 @@ use crate::error::Error;
 use crate::state::EventSemantics;
 use serde_hex::{Compact, SerHex};
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Event {
     #[serde(rename = "i")]
     pub prefix: IdentifierPrefix,

--- a/src/event/sections/mod.rs
+++ b/src/event/sections/mod.rs
@@ -141,7 +141,7 @@ mod empty_string_as_none {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
 pub struct WitnessConfig {
     #[serde(rename = "wt", with = "SerHex::<Compact>")]
     pub tally: u64,
@@ -153,7 +153,7 @@ pub struct WitnessConfig {
     pub graft: Vec<BasicPrefix>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
 pub struct InceptionWitnessConfig {
     #[serde(rename = "wt", with = "SerHex::<Compact>")]
     pub tally: u64,

--- a/src/event/sections/seal.rs
+++ b/src/event/sections/seal.rs
@@ -2,7 +2,7 @@ use crate::prefix::{IdentifierPrefix, SelfAddressingPrefix};
 use serde::{Deserialize, Serialize};
 use serde_hex::{Compact, SerHex};
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum Seal {
     Location(LocationSeal),
@@ -11,19 +11,19 @@ pub enum Seal {
     Root(RootSeal),
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct DigestSeal {
     #[serde(rename = "d")]
     pub dig: SelfAddressingPrefix,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct RootSeal {
     #[serde(rename = "rd")]
     pub tree_root: SelfAddressingPrefix,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
 pub struct EventSeal {
     #[serde(rename = "i")]
     pub prefix: IdentifierPrefix,
@@ -35,7 +35,7 @@ pub struct EventSeal {
     pub event_digest: SelfAddressingPrefix,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
 pub struct LocationSeal {
     #[serde(rename = "i")]
     pub prefix: IdentifierPrefix,
@@ -50,7 +50,7 @@ pub struct LocationSeal {
     pub prior_digest: SelfAddressingPrefix,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct DelegatingEventSeal {
     #[serde(rename = "i")]
     pub prefix: IdentifierPrefix,

--- a/src/event_message/mod.rs
+++ b/src/event_message/mod.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use serialization_info::*;
 pub mod parse;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct EventMessage {
     /// Serialization Information
     ///

--- a/src/event_message/parse.rs
+++ b/src/event_message/parse.rs
@@ -16,13 +16,13 @@ use rmp_serde as serde_mgpk;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::io::Cursor;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct DeserializedEvent<'a> {
     pub event: EventMessage,
     pub raw: &'a [u8],
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct DeserializedSignedEvent<'a> {
     pub event: DeserializedEvent<'a>,
     pub signatures: Vec<AttachedSignaturePrefix>,

--- a/src/event_message/serialization_info.rs
+++ b/src/event_message/serialization_info.rs
@@ -41,7 +41,7 @@ impl FromStr for SerializationFormats {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct SerializationInfo {
     pub major_version: u8,
     pub minor_version: u8,

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -71,6 +71,13 @@ impl<D: EventDatabase> EventProcessor<D> {
         Ok(Some(state))
     }
 
+    /// Get KERL for Prefix
+    ///
+    /// Returns the current validated KEL for a given Prefix
+    pub fn get_kerl(&self, id: &IdentifierPrefix) -> Result<Option<Vec<u8>>, Error> {
+        self.db.get_kerl(id).map_err(|_| Error::StorageError)
+    }
+
     /// Get keys from Establishment Event
     ///
     /// Returns the current Key Config associated with

--- a/src/processor/tests.rs
+++ b/src/processor/tests.rs
@@ -78,8 +78,8 @@ fn test_process() -> Result<(), Error> {
     assert_eq!(ixn_from_db, Some(raw_parsed));
 
     // Construct partially signed interaction event.
-    let ixn_raw = br#"{"v":"KERI10JSON000098_","i":"EJPRBUSEdUuZnh9kRGg8y7uBJDxTGZdp4YeUSqBv5sEk","s":"3","t":"ixn","p":"EpAHPuE6SqPw_oodA7utfEUxFh2pL6iYJ7Uwy1UQqi08","a":[]}-AADAAsMWMYvI8ymFUmdwiOSBqS16nOSYT70xKMztFprjdpDQC4VGsOcChyd9XsCqu_UId0H2-gbesX-ql3skh-qf0DwABVVVWbOMbnO8gn4EOAiY9wrGP7Q1uh8a-WUyPYlaii3iQ2Qucu_kzznl7MgnKeH2c7m_3h7HfoebC5wngg5-SAQACiau2633rcR8zTlvCMq4tQL2BpPMV61FgAU-9RVvBsbSkEs00mxwoxN_Xz4nqUaCX9bR8t9Mx3mgABXemOeTMAQ"#;
-    let deserialized_ixn = parse::signed_message(ixn_raw).unwrap().1;
+    let ixn_raw_2 = br#"{"v":"KERI10JSON000098_","i":"EJPRBUSEdUuZnh9kRGg8y7uBJDxTGZdp4YeUSqBv5sEk","s":"3","t":"ixn","p":"EpAHPuE6SqPw_oodA7utfEUxFh2pL6iYJ7Uwy1UQqi08","a":[]}-AADAAsMWMYvI8ymFUmdwiOSBqS16nOSYT70xKMztFprjdpDQC4VGsOcChyd9XsCqu_UId0H2-gbesX-ql3skh-qf0DwABVVVWbOMbnO8gn4EOAiY9wrGP7Q1uh8a-WUyPYlaii3iQ2Qucu_kzznl7MgnKeH2c7m_3h7HfoebC5wngg5-SAQACiau2633rcR8zTlvCMq4tQL2BpPMV61FgAU-9RVvBsbSkEs00mxwoxN_Xz4nqUaCX9bR8t9Mx3mgABXemOeTMAQ"#;
+    let deserialized_ixn = parse::signed_message(ixn_raw_2).unwrap().1;
     // Make event partially signed.
     let partially_signed_deserialized_ixn = match deserialized_ixn {
         Deserialized::Event(mut e) => {
@@ -109,6 +109,14 @@ fn test_process() -> Result<(), Error> {
     // Check if processed event is in kel. It shouldn't.
     let raw_from_db = event_processor.db.last_event_at_sn(&id, 4);
     assert!(matches!(raw_from_db, Ok(None)));
+
+    let id: IdentifierPrefix = "EJPRBUSEdUuZnh9kRGg8y7uBJDxTGZdp4YeUSqBv5sEk".parse()?;
+    let mut kel = Vec::new();
+    kel.extend(icp_raw);
+    kel.extend(rot_raw);
+    kel.extend(ixn_raw);
+
+    assert_eq!(event_processor.get_kerl(&id)?, Some(kel));
 
     Ok(())
 }


### PR DESCRIPTION
adds functionality to `EventDatabase` and `EventProcessor` to retrieve the full KERL for an identifier. Other convenience fns might also be desired (e.g. get signed event + receipts at sn)