### PR TITLE
pin ursa commit to pre-build-issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ lmdb = ["rkv", "bincode"]
 default = ["lmdb"]
 
 [dependencies]
-ursa = { git = "https://github.com/hyperledger/ursa", branch = "main", default-features = false, features = ["portable"]}
+ursa = { git = "https://github.com/hyperledger/ursa", rev = "d4af8efd", default-features = false, features = ["portable"]}
 base64 = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,3 @@ pub mod prefix;
 pub mod processor;
 pub mod signer;
 pub mod state;
-
-#[cfg(feature = "exp_ursa")]
-pub use ursa;


### PR DESCRIPTION
Ursa has been causing some build issues since [this PR](https://github.com/hyperledger/ursa/pull/171). This change pins Ursa to the commit prior to that.