### PR TITLE
Update keri module

### DIFF
--- a/src/keri/mod.rs
+++ b/src/keri/mod.rs
@@ -210,4 +210,8 @@ impl<D: EventDatabase, K: KeyManager> Keri<D, K> {
     ) -> Result<Option<IdentifierState>, Error> {
         self.processor.compute_state(prefix)
     }
+
+    pub fn get_state_for_seal(&self, seal: &EventSeal) -> Result<Option<IdentifierState>, Error> {
+        self.processor.compute_state_at_sn(&seal.prefix, seal.sn)
+    }
 }


### PR DESCRIPTION
This PR fixes how validator receipts are created. Now we use the last establishment event seal rather than just the last event seal. Also, it adds the method for getting state for given sn.