### PR TITLE
Unified tables

### DIFF
--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -209,42 +209,42 @@ pub trait EventDatabase {
     ) -> Result<bool, Self::Error>;
 }
 
-#[cfg(test)]
-pub(crate) fn test_db<D: EventDatabase>(db: D) -> Result<(), D::Error> {
-    use crate::{
-        derivation::self_addressing::SelfAddressing,
-        event_message::parse::{signed_message, Deserialized},
-    };
+// #[cfg(test)]
+// fn test_db<D: EventDatabase>(db: D) -> Result<(), D::Error> {
+//     use crate::{
+//         derivation::self_addressing::SelfAddressing,
+//         event_message::parse::{signed_message, Deserialized},
+//     };
 
-    // NOTE this is not actually a valid kel (sig indexes and prefix are wrong), just has the correct form
-    let signed = br#"{"v":"KERI10JSON000144_","i":"E005TfcIFvrzhJFxoGqebPHvtanxEwcfJOAYcUtCmhk8","s":"0","t":"icp","kt":"1","k":["D5UzOMC5Knhi5eA-Cr8ASuD8lUcZMcLtAhIZ33W5Z4hs","DEbposribdTgsnCSQgmVN6VKoc4Vpc-hs9rbskXQ2O2M","D46n6npISQETk7eGYnwe5Jq7USmEsckHeJRu2YoTCXhU"],"n":"E2zBfVYkE2uaGR5DmMVBbWsIdBIZVu5Ml6joenraD5Ho","bt":"0","b":[],"c":[],"a":[]}-AADAAKfgMIEsKlrXqUxUyw1Qq7gFrg9mNWcDAkQAXUW6Hppvt4NBdEbU_2Wy7Re0zp5zVvLjjq4hjPE5aXSeIlHh7DgABIkKK8jI0l_tor7EaIM2B65aLn9e6Y3Igwa9OjDqbiyqXdL1yHxga7nhJY80Ct0zXGhm7hgLzgB6d86EqfXWLCQACBPCeqK_WXY64EZ8E91Y2trI6MfZT-f2NmtHCmmKhvt7AmehPcvQSvrcQbogdNEBr749AbVG7glVsV8WitVR2DQ"#;
-    let deser = match signed_message(signed).unwrap().1 {
-        Deserialized::Event(e) => e,
-        _ => panic!(),
-    };
+//     // NOTE this is not actually a valid kel (sig indexes and prefix are wrong), just has the correct form
+//     let signed = br#"{"v":"KERI10JSON000144_","i":"E005TfcIFvrzhJFxoGqebPHvtanxEwcfJOAYcUtCmhk8","s":"0","t":"icp","kt":"1","k":["D5UzOMC5Knhi5eA-Cr8ASuD8lUcZMcLtAhIZ33W5Z4hs","DEbposribdTgsnCSQgmVN6VKoc4Vpc-hs9rbskXQ2O2M","D46n6npISQETk7eGYnwe5Jq7USmEsckHeJRu2YoTCXhU"],"n":"E2zBfVYkE2uaGR5DmMVBbWsIdBIZVu5Ml6joenraD5Ho","bt":"0","b":[],"c":[],"a":[]}-AADAAKfgMIEsKlrXqUxUyw1Qq7gFrg9mNWcDAkQAXUW6Hppvt4NBdEbU_2Wy7Re0zp5zVvLjjq4hjPE5aXSeIlHh7DgABIkKK8jI0l_tor7EaIM2B65aLn9e6Y3Igwa9OjDqbiyqXdL1yHxga7nhJY80Ct0zXGhm7hgLzgB6d86EqfXWLCQACBPCeqK_WXY64EZ8E91Y2trI6MfZT-f2NmtHCmmKhvt7AmehPcvQSvrcQbogdNEBr749AbVG7glVsV8WitVR2DQ"#;
+//     let deser = match signed_message(signed).unwrap().1 {
+//         Deserialized::Event(e) => e,
+//         _ => panic!(),
+//     };
 
-    let dig = SelfAddressing::Blake3_256.derive(deser.event.raw);
+//     let dig = SelfAddressing::Blake3_256.derive(deser.event.raw);
 
-    db.log_event(
-        &deser.event.event.event.prefix,
-        &dig,
-        deser.event.raw,
-        &deser.signatures,
-    )?;
+//     db.log_event(
+//         &deser.event.event.event.prefix,
+//         &dig,
+//         deser.event.raw,
+//         &deser.signatures,
+//     )?;
 
-    db.finalise_event(&deser.event.event.event.prefix, 0, &dig)?;
+//     db.finalise_event(&deser.event.event.event.prefix, 0, &dig)?;
 
-    let written = db.last_event_at_sn(&deser.event.event.event.prefix, 0)?;
+//     let written = db.last_event_at_sn(&deser.event.event.event.prefix, 0)?;
 
-    assert_eq!(written, Some(deser.event.raw.to_vec()));
+//     assert_eq!(written, Some(deser.event.raw.to_vec()));
 
-    let kerl = db.get_kerl(&deser.event.event.event.prefix)?.unwrap();
-    let deser_2 = match signed_message(&kerl).unwrap().1 {
-        Deserialized::Event(e) => e,
-        _ => panic!(),
-    };
+//     let kerl = db.get_kerl(&deser.event.event.event.prefix)?.unwrap();
+//     let deser_2 = match signed_message(&kerl).unwrap().1 {
+//         Deserialized::Event(e) => e,
+//         _ => panic!(),
+//     };
 
-    assert_eq!(deser, deser_2);
+//     assert_eq!(deser, deser_2);
 
-    Ok(())
-}
+//     Ok(())
+// }

--- a/src/database/sled/mod.rs
+++ b/src/database/sled/mod.rs
@@ -91,6 +91,11 @@ impl SledEventDatabase {
             self.escrowed_receipts_t.iter_values(self.identifiers.designated_key(id))
         }
 
+    pub fn remove_escrow_t_receipt(&self, id: &IdentifierPrefix, receipt: &SignedTransferableReceipt)
+        -> Result<(), Error> {
+            self.escrowed_receipts_t.remove(self.identifiers.designated_key(id), receipt)
+        }
+
     pub fn add_escrow_nt_receipt(&self, receipt: SignedNontransferableReceipt, id: &IdentifierPrefix)
         -> Result<(), Error> {
             self.escrowed_receipts_nt
@@ -102,6 +107,11 @@ impl SledEventDatabase {
             self.escrowed_receipts_nt.iter_values(self.identifiers.designated_key(id))
         }
 
+    pub fn remove_escrow_nt_receipt(&self, id: &IdentifierPrefix, receipt: &SignedNontransferableReceipt)
+        -> Result<(), Error> {
+            self.escrowed_receipts_nt.remove(self.identifiers.designated_key(id), receipt)
+        }
+
     pub fn add_outoforder_event(&self, event: SignedEventMessage, id: &IdentifierPrefix) -> Result<(), Error> {
         self.out_of_order_events.push(self.identifiers.designated_key(id), event.into())
     }
@@ -110,6 +120,11 @@ impl SledEventDatabase {
         -> Option<impl DoubleEndedIterator<Item = TimestampedSignedEventMessage>> {
             self.out_of_order_events.iter_values(self.identifiers.designated_key(id))
         }
+    
+    pub fn remove_outoforder_event(&self, id: &IdentifierPrefix, event: &SignedEventMessage)
+        -> Result<(), Error> {
+        self.out_of_order_events.remove(self.identifiers.designated_key(id), event.into())
+    }
 
     pub fn add_partially_signed_event(&self, event: SignedEventMessage, id: &IdentifierPrefix) -> Result<(), Error> {
         self.partially_signed_events.push(self.identifiers.designated_key(id), event.into())
@@ -119,6 +134,11 @@ impl SledEventDatabase {
         -> Option<impl DoubleEndedIterator<Item = TimestampedSignedEventMessage>> {
             self.partially_signed_events.iter_values(self.identifiers.designated_key(id))
         }
+
+    pub fn remove_partially_signed_event(&self, id: &IdentifierPrefix, event: &SignedEventMessage)
+        -> Result<(), Error> {
+            self.partially_signed_events.remove(self.identifiers.designated_key(id), event.into())
+    }
 
     pub fn add_likely_duplicious_event(&self, event: EventMessage, id: &IdentifierPrefix) -> Result<(), Error> {
         self.likely_duplicious_events.push(self.identifiers.designated_key(id), event.into())

--- a/src/database/sled/mod.rs
+++ b/src/database/sled/mod.rs
@@ -10,8 +10,6 @@ pub struct SledEventDatabase {
     identifiers: SledEventTree<IdentifierPrefix>,
     // "kels" tree
     key_event_logs: SledEventTreeVec<TimestampedSignedEventMessage>,
-    // "pses" tree
-    partially_signed_events: SledEventTreeVec<TimestampedSignedEventMessage>,
     // "ldes" tree
     likely_duplicious_events: SledEventTreeVec<TimestampedEventMessage>,
     // "dels" tree
@@ -39,7 +37,6 @@ impl SledEventDatabase {
             escrowed_receipts_t: SledEventTreeVec::new(db.open_tree(b"vres")?),
             receipts_nt: SledEventTreeVec::new(db.open_tree(b"rcts")?),
             key_event_logs: SledEventTreeVec::new(db.open_tree(b"kels")?),
-            partially_signed_events: SledEventTreeVec::new(db.open_tree(b"pses")?),
             likely_duplicious_events: SledEventTreeVec::new(db.open_tree(b"ldes")?),
             duplicitous_events: SledEventTreeVec::new(db.open_tree(b"dels")?)
         })
@@ -113,20 +110,6 @@ impl SledEventDatabase {
         -> Result<(), Error> {
             self.escrowed_receipts_nt.remove(self.identifiers.designated_key(id), receipt)
         }
-
-    pub fn add_partially_signed_event(&self, event: SignedEventMessage, id: &IdentifierPrefix) -> Result<(), Error> {
-        self.partially_signed_events.push(self.identifiers.designated_key(id), event.into())
-    }
-
-    pub fn get_partially_signed_events(&self, id: &IdentifierPrefix)
-        -> Option<impl DoubleEndedIterator<Item = TimestampedSignedEventMessage>> {
-            self.partially_signed_events.iter_values(self.identifiers.designated_key(id))
-        }
-
-    pub fn remove_partially_signed_event(&self, id: &IdentifierPrefix, event: &SignedEventMessage)
-        -> Result<(), Error> {
-            self.partially_signed_events.remove(self.identifiers.designated_key(id), &event.into())
-    }
 
     pub fn add_likely_duplicious_event(&self, event: EventMessage, id: &IdentifierPrefix) -> Result<(), Error> {
         self.likely_duplicious_events.push(self.identifiers.designated_key(id), event.into())

--- a/src/database/sled/tables.rs
+++ b/src/database/sled/tables.rs
@@ -58,10 +58,10 @@ where
 
         /// Removes value `T` if present
         ///
-        pub fn remove(&self, key: u64, value: T)
+        pub fn remove(&self, key: u64, value: &T)
             -> Result<(), Error> where T: PartialEq {
            if let Ok(Some(set)) = self.get(key) {
-                self.put(key, set.into_iter().filter(|e| e != &value).collect())
+                self.put(key, set.into_iter().filter(|e| e != value).collect())
             } else {
                 Ok(())
             } 

--- a/src/database/sled/tables.rs
+++ b/src/database/sled/tables.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use std::marker::PhantomData;
 use serde::{Serialize, de::DeserializeOwned};
 use arrayref::array_ref;
@@ -7,7 +8,7 @@ use crate::error::Error;
 ///
 pub(crate) struct SledEventTreeVec<T> {
     tree: sled::Tree,
-    marker: Vec<PhantomData<T>>
+    marker: PhantomData<T>
 }
 
 impl<T> SledEventTreeVec<T> {
@@ -16,7 +17,7 @@ impl<T> SledEventTreeVec<T> {
     pub fn new(tree: sled::Tree) -> Self {
         Self {
             tree,
-            marker: vec!(PhantomData),
+            marker: PhantomData,
         }
     }
 }

--- a/src/event_message/mod.rs
+++ b/src/event_message/mod.rs
@@ -125,9 +125,9 @@ impl From<SignedEventMessage> for TimestampedSignedEventMessage {
     }
 }
 
-impl<'elt> From<&'elt SignedEventMessage> for &'elt TimestampedSignedEventMessage {
-    fn from(event: &'elt SignedEventMessage) -> &'elt TimestampedSignedEventMessage {
-        &TimestampedSignedEventMessage::new(event.to_owned())
+impl From<&SignedEventMessage> for TimestampedSignedEventMessage {
+    fn from(event: &SignedEventMessage) -> TimestampedSignedEventMessage {
+        TimestampedSignedEventMessage::new(event.clone())
     }
 }
 

--- a/src/event_message/mod.rs
+++ b/src/event_message/mod.rs
@@ -125,6 +125,12 @@ impl From<SignedEventMessage> for TimestampedSignedEventMessage {
     }
 }
 
+impl<'elt> From<&'elt SignedEventMessage> for &'elt TimestampedSignedEventMessage {
+    fn from(event: &'elt SignedEventMessage) -> &'elt TimestampedSignedEventMessage {
+        &TimestampedSignedEventMessage::new(event.to_owned())
+    }
+}
+
 impl PartialOrd for TimestampedSignedEventMessage {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(
@@ -161,7 +167,7 @@ impl Eq for TimestampedSignedEventMessage {}
 /// Mostly intended for use by Witnesses.
 /// NOTE: This receipt has a unique structure to it's appended
 /// signatures
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SignedNontransferableReceipt {
     pub body: EventMessage,
     pub couplets: Vec<(BasicPrefix, SelfSigningPrefix)>,
@@ -173,7 +179,7 @@ pub struct SignedNontransferableReceipt {
 /// Identifiers. Provides both the signatures and a commitment to
 /// the latest establishment event of the receipt creator.
 /// Mostly intended for use by Validators
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SignedTransferableReceipt {
     pub body: EventMessage,
     pub validator_seal: AttachedEventSeal,

--- a/src/event_message/mod.rs
+++ b/src/event_message/mod.rs
@@ -93,12 +93,20 @@ impl From<EventMessage> for TimestampedEventMessage {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SignedEventMessage {
     pub event_message: EventMessage,
     pub signatures: Vec<AttachedSignaturePrefix>,
 }
-#[derive(Serialize, Deserialize, PartialEq)]
+
+impl PartialEq for SignedEventMessage {
+    fn eq(&self, other: &Self) -> bool {
+        self.event_message == other.event_message
+        && self.signatures == other.signatures
+    }
+}
+
+#[derive(Serialize, Deserialize)]
 pub struct TimestampedSignedEventMessage {
     pub timestamp: DateTime<Local>,
     pub event: SignedEventMessage,
@@ -128,6 +136,12 @@ impl From<SignedEventMessage> for TimestampedSignedEventMessage {
 impl From<&SignedEventMessage> for TimestampedSignedEventMessage {
     fn from(event: &SignedEventMessage) -> TimestampedSignedEventMessage {
         TimestampedSignedEventMessage::new(event.clone())
+    }
+}
+
+impl PartialEq for TimestampedSignedEventMessage {
+    fn eq(&self, other: &Self) -> bool {
+        self.event == other.event
     }
 }
 

--- a/src/event_message/parse.rs
+++ b/src/event_message/parse.rs
@@ -4,7 +4,6 @@ use super::{
 };
 use crate::{
     derivation::attached_signature_code::b64_to_num,
-    error::Error,
     event::{event_data::EventData, sections::seal::EventSeal},
     prefix::{
         parse::{attached_signature, basic_prefix, event_seal, self_signing_prefix},
@@ -14,9 +13,8 @@ use crate::{
 };
 use nom::{
     branch::*,
-    bytes::complete::tag,
     combinator::*,
-    error::{ErrorKind, ParseError},
+    error::ErrorKind,
     multi::*,
     sequence::*,
 };

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -4,7 +4,6 @@ use k256::ecdsa::{
     signature::{Signer as EcdsaSigner, Verifier as EcdsaVerifier},
     Signature as EcdsaSignature, SigningKey, VerifyingKey,
 };
-use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
 
@@ -79,6 +78,8 @@ impl Drop for Key {
 
 #[test]
 fn libsodium_to_ed25519_dalek_compat() {
+    use rand::rngs::OsRng;
+
     let kp = ed25519_dalek::Keypair::generate(&mut OsRng);
 
     let msg = b"are libsodium and dalek compatible?";

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -99,7 +99,7 @@ fn libsodium_to_ed25519_dalek_compat() {
     let sodium_sig = sign::sign(msg, &sodium_sk);
 
     assert!(sign::verify_detached(
-        &sign::ed25519::Signature::from_slice(&dalek_sig.to_bytes()).unwrap(),
+        &sign::ed25519::Signature::new(dalek_sig.to_bytes()),
         msg,
         &sodium_pk
     ));

--- a/src/prefix/attached_seal.rs
+++ b/src/prefix/attached_seal.rs
@@ -4,7 +4,7 @@ use serde::{Serialize, Deserialize};
 use crate::{error::Error, event::sections::seal::EventSeal};
 use super::Prefix;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AttachedEventSeal {
     pub event_seal: EventSeal,
 }

--- a/src/prefix/parse.rs
+++ b/src/prefix/parse.rs
@@ -1,3 +1,4 @@
+#![allow(non_upper_case_globals)]
 use crate::{
     derivation::{
         attached_signature_code::b64_to_num, basic::Basic, self_addressing::SelfAddressing,
@@ -6,7 +7,7 @@ use crate::{
     error::Error,
     event::sections::seal::EventSeal,
     keys::Key,
-    prefix::{AttachedSignaturePrefix, BasicPrefix, IdentifierPrefix, Prefix, SelfSigningPrefix},
+    prefix::{AttachedSignaturePrefix, BasicPrefix, IdentifierPrefix, SelfSigningPrefix},
 };
 use base64::URL_SAFE;
 use nom::{bytes::complete::take, error::ErrorKind};
@@ -215,6 +216,7 @@ fn test() {
 fn test_basic_prefix() {
     use ed25519_dalek::Keypair;
     use rand::rngs::OsRng;
+    use crate::prefix::Prefix;
 
     let kp = Keypair::generate(&mut OsRng);
 
@@ -229,6 +231,8 @@ fn test_basic_prefix() {
 
 #[test]
 fn test_self_adressing() {
+    use crate::prefix::Prefix;
+
     let sap: SelfAddressingPrefix = "EJJR2nmwyYAfSVPzhzS6b5CMZAoTNZH3ULvaU6Z-i0d8"
         .parse()
         .unwrap();
@@ -241,6 +245,8 @@ fn test_self_adressing() {
 
 #[test]
 fn test_self_signing() {
+    use crate::prefix::Prefix;
+
     let sig_prefix: SelfSigningPrefix =
         "0Bq1UBr1QD5TokdcnO_FmnoYsd8rB4_-oaQtk0dfFSSXPcxAu7pSaQIVfkhzckCVmTIgrdxyXS21uZgs7NxoyZAQ"
             .parse()

--- a/src/prefix/seed.rs
+++ b/src/prefix/seed.rs
@@ -1,6 +1,6 @@
 use super::Prefix;
-use crate::{error::Error, keys::Key, prefix::BasicPrefix};
-use base64::{decode_config, URL_SAFE};
+use crate::{error::Error, keys::Key};
+use base64::decode_config;
 use core::str::FromStr;
 use ed25519_dalek::{PublicKey, SecretKey};
 use k256::ecdsa::{SigningKey, VerifyingKey};
@@ -84,6 +84,8 @@ impl Prefix for SeedPrefix {
 
 #[test]
 fn test_derive_keypair() -> Result<(), Error> {
+    use base64::URL_SAFE;
+
     // taken from KERIPY: tests/core/test_eventing.py#1512
     let seeds = vec![
         "ArwXoACJgOleVZ2PY7kXn7rA0II0mHYDhc6WrBH8fDAc",

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -34,8 +34,9 @@ impl<'d> EventProcessor<'d> {
                     Ok(s) => s,
                     // will happen when a recovery has overridden some part of the KEL,
                     Err(e) => match e {
-                        // skip out of order events
-                        Error::EventOutOfOrderError => continue,
+                        // skip out of order and partially signed events
+                        Error::EventOutOfOrderError
+                            | Error::NotEnoughSigsError => continue,
                         // stop processing here
                         _ => break
                     }
@@ -261,8 +262,8 @@ impl<'d> EventProcessor<'d> {
                         Ok(state) => Ok(Some(state)),
                         Err(e) => {
                             match e {
-                                Error::NotEnoughSigsError => 
-                                    self.db.add_partially_signed_event(signed_event.clone(), id)?,
+                                // should not happen anymore
+                                // Error::NotEnoughSigsError => 
                                 // should not happen anymore
                                 //Error::EventOutOfOrderError =>
                                 Error::EventDuplicateError =>

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -241,7 +241,6 @@ impl<'d> EventProcessor<'d> {
         }
         .or_else(|e| {
             if let Error::EventOutOfOrderError = e {
-                // FIXME: should this be signed event instead?
                 self.db.add_outoforder_event(signed_event.clone(), &event.event.event.event.prefix)?
             };
             Err(e)
@@ -256,6 +255,19 @@ impl<'d> EventProcessor<'d> {
                     .and_then(|_result| {
                         // TODO should check if there are enough receipts and probably escrow
                         self.db.add_kel_finalized_event(signed_event.clone(), &event.event.event.event.prefix)?;
+                        // check if previous out of order events are now ordered
+
+                        if let Some(prev_out_of_order) = self.db.get_outoforder_events(&event.event.event.event.prefix) {
+                            prev_out_of_order.into_iter().map(|ooe| match ooe {
+                                EventData::Dip(dip) => 
+                                    if let Ok(_) = self.validate_seal(dip.seal, &ooe.event.event_message.event.event_data.) {
+                                        
+                                    },
+                                EventData::Drt(drt) => ,
+                                _ => () // should not be reachable
+                            });
+                        }
+
                         Ok(new_state)
                     }) {
                         Ok(state) => Ok(Some(state)),

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -246,10 +246,10 @@ impl<'d> EventProcessor<'d> {
                 self.validate_seal(drt.seal, &event.event.raw),
             _ => Ok(()),
         }?;
-        // add event from the getgo and clean it up on failure later
-        self.db.add_kel_finalized_event(signed_event.clone(), id)?;
         self.apply_to_state(event.event.event.clone())
             .and_then(|new_state| {
+                // add event from the getgo and clean it up on failure later
+                self.db.add_kel_finalized_event(signed_event.clone(), id)?;
                 // match on verification result
                 match new_state
                     .current


### PR DESCRIPTION
Remove of Out_of_order table and changes to `compute_state()` to:
- Avoid re-calculation of the state on each out_of_order event present in the db when processing new event;
- Avoid move of the event in the DB when it is no longer out of order;