### PR TITLE
Keys module refactor

### DIFF
--- a/src/derivation/basic.rs
+++ b/src/derivation/basic.rs
@@ -1,5 +1,5 @@
 use super::DerivationCode;
-use crate::{error::Error, keys::Key, prefix::BasicPrefix};
+use crate::{error::Error, prefix::{BasicPrefix, basic::PublicKey}};
 use core::str::FromStr;
 use serde::{Deserialize, Serialize};
 
@@ -19,7 +19,7 @@ pub enum Basic {
 }
 
 impl Basic {
-    pub fn derive(&self, public_key: Key) -> BasicPrefix {
+    pub fn derive(&self, public_key: PublicKey) -> BasicPrefix {
         BasicPrefix::new(*self, public_key)
     }
 }

--- a/src/derivation/basic.rs
+++ b/src/derivation/basic.rs
@@ -1,5 +1,5 @@
 use super::DerivationCode;
-use crate::{error::Error, prefix::{BasicPrefix, basic::PublicKey}};
+use crate::{error::Error, keys::PublicKey, prefix::BasicPrefix};
 use core::str::FromStr;
 use serde::{Deserialize, Serialize};
 

--- a/src/event/sections/key_config.rs
+++ b/src/event/sections/key_config.rs
@@ -1,10 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    derivation::self_addressing::SelfAddressing,
-    error::Error,
-    prefix::{AttachedSignaturePrefix, BasicPrefix, Prefix, SelfAddressingPrefix},
-};
+use crate::{derivation::self_addressing::SelfAddressing, error::Error, prefix::{AttachedSignaturePrefix, BasicPrefix, Prefix, SelfAddressingPrefix}};
 
 use super::threshold::SignatureThreshold;
 
@@ -185,17 +181,17 @@ fn test_next_commitment() {
 #[test]
 fn test_threshold() -> Result<(), Error> {
     use crate::derivation::{basic::Basic, self_signing::SelfSigning};
-    use crate::keys::Key;
+    use crate::{keys::PrivateKey, prefix::basic::PublicKey};
     use ed25519_dalek::Keypair;
     use rand::rngs::OsRng;
 
-    let (pub_keys, priv_keys): (Vec<BasicPrefix>, Vec<Key>) = [0, 1, 2]
+    let (pub_keys, priv_keys): (Vec<BasicPrefix>, Vec<PrivateKey>) = [0, 1, 2]
         .iter()
         .map(|_| {
             let kp = Keypair::generate(&mut OsRng);
             (
-                Basic::Ed25519.derive(Key::new(kp.public.to_bytes().to_vec())),
-                Key::new(kp.secret.to_bytes().to_vec()),
+                Basic::Ed25519.derive(PublicKey::new(kp.public.to_bytes().to_vec())),
+                PrivateKey::new(kp.secret.to_bytes().to_vec()),
             )
         })
         .unzip();
@@ -207,7 +203,7 @@ fn test_threshold() -> Result<(), Error> {
             .iter()
             .map(|_| {
                 let kp = Keypair::generate(&mut OsRng);
-                Basic::Ed25519.derive(Key::new(kp.public.to_bytes().to_vec()))
+                Basic::Ed25519.derive(PublicKey::new(kp.public.to_bytes().to_vec()))
             })
             .collect();
         nxt_commitment(&next_threshold, &next_keys, &SelfAddressing::Blake3_256)

--- a/src/event/sections/key_config.rs
+++ b/src/event/sections/key_config.rs
@@ -181,7 +181,7 @@ fn test_next_commitment() {
 #[test]
 fn test_threshold() -> Result<(), Error> {
     use crate::derivation::{basic::Basic, self_signing::SelfSigning};
-    use crate::{keys::PrivateKey, prefix::basic::PublicKey};
+    use crate::keys::{PrivateKey, PublicKey};
     use ed25519_dalek::Keypair;
     use rand::rngs::OsRng;
 

--- a/src/event_message/event_msg_builder.rs
+++ b/src/event_message/event_msg_builder.rs
@@ -1,8 +1,4 @@
-use crate::{
-    derivation::{basic::Basic, self_addressing::SelfAddressing},
-    error::Error,
-    event::sections::key_config::nxt_commitment,
-    event::{
+use crate::{derivation::{basic::Basic, self_addressing::SelfAddressing}, error::Error, event::sections::key_config::nxt_commitment, event::{
         event_data::{
             delegated::{DelegatedInceptionEvent, DelegatedRotationEvent},
             interaction::InteractionEvent,
@@ -10,17 +6,13 @@ use crate::{
         },
         sections::{threshold::SignatureThreshold, seal::LocationSeal, WitnessConfig},
         SerializationFormats,
-    },
-    event::{
+    }, event::{
         event_data::{inception::InceptionEvent, EventData},
         sections::seal::Seal,
         sections::InceptionWitnessConfig,
         sections::KeyConfig,
         Event, EventMessage,
-    },
-    keys::Key,
-    prefix::{BasicPrefix, IdentifierPrefix, SelfAddressingPrefix},
-};
+    }, prefix::{BasicPrefix, IdentifierPrefix, SelfAddressingPrefix, basic::PublicKey}};
 use ed25519_dalek::Keypair;
 use rand::rngs::OsRng;
 use std::str::FromStr;
@@ -65,8 +57,8 @@ impl EventMsgBuilder {
         let mut rng = OsRng {};
         let kp = Keypair::generate(&mut rng);
         let nkp = Keypair::generate(&mut rng);
-        let pk = Key::new(kp.public.to_bytes().to_vec());
-        let npk = Key::new(nkp.public.to_bytes().to_vec());
+        let pk = PublicKey::new(kp.public.to_bytes().to_vec());
+        let npk = PublicKey::new(nkp.public.to_bytes().to_vec());
         let basic_pref = Basic::Ed25519.derive(pk);
         let dummy_loc_seal = LocationSeal {
             prefix: IdentifierPrefix::from_str("EZAoTNZH3ULvaU6Z-i0d8JJR2nmwyYAfSVPzhzS6b5CM")?,

--- a/src/event_message/event_msg_builder.rs
+++ b/src/event_message/event_msg_builder.rs
@@ -12,7 +12,7 @@ use crate::{derivation::{basic::Basic, self_addressing::SelfAddressing}, error::
         sections::InceptionWitnessConfig,
         sections::KeyConfig,
         Event, EventMessage,
-    }, prefix::{BasicPrefix, IdentifierPrefix, SelfAddressingPrefix, basic::PublicKey}};
+    }, keys::PublicKey, prefix::{BasicPrefix, IdentifierPrefix, SelfAddressingPrefix}};
 use ed25519_dalek::Keypair;
 use rand::rngs::OsRng;
 use std::str::FromStr;

--- a/src/event_message/mod.rs
+++ b/src/event_message/mod.rs
@@ -412,7 +412,7 @@ mod tests {
             event_data::{inception::InceptionEvent, EventData},
             sections::KeyConfig,
             sections::{threshold::SignatureThreshold, InceptionWitnessConfig},
-        }, keys::PrivateKey, prefix::{AttachedSignaturePrefix, IdentifierPrefix, basic::PublicKey}};
+        }, keys::{PrivateKey, PublicKey}, prefix::{AttachedSignaturePrefix, IdentifierPrefix }};
     use ed25519_dalek::Keypair;
     use rand::rngs::OsRng;
 

--- a/src/event_message/mod.rs
+++ b/src/event_message/mod.rs
@@ -408,16 +408,11 @@ mod tests {
 
     use self::{event_msg_builder::EventType, test_utils::test_mock_event_sequence};
     use super::*;
-    use crate::{
-        derivation::{basic::Basic, self_addressing::SelfAddressing, self_signing::SelfSigning},
-        event::{
+    use crate::{derivation::{basic::Basic, self_addressing::SelfAddressing, self_signing::SelfSigning}, event::{
             event_data::{inception::InceptionEvent, EventData},
             sections::KeyConfig,
             sections::{threshold::SignatureThreshold, InceptionWitnessConfig},
-        },
-        keys::Key,
-        prefix::{AttachedSignaturePrefix, IdentifierPrefix},
-    };
+        }, keys::PrivateKey, prefix::{AttachedSignaturePrefix, IdentifierPrefix, basic::PublicKey}};
     use ed25519_dalek::Keypair;
     use rand::rngs::OsRng;
 
@@ -428,11 +423,11 @@ mod tests {
         let kp1 = Keypair::generate(&mut OsRng);
 
         // get two ed25519 keypairs
-        let pub_key0 = Key::new(kp0.public.to_bytes().to_vec());
-        let priv_key0 = Key::new(kp0.secret.to_bytes().to_vec());
+        let pub_key0 = PublicKey::new(kp0.public.to_bytes().to_vec());
+        let priv_key0 = PrivateKey::new(kp0.secret.to_bytes().to_vec());
         let (pub_key1, _priv_key1) = (
-            Key::new(kp1.public.to_bytes().to_vec()),
-            Key::new(kp1.secret.to_bytes().to_vec()),
+            PublicKey::new(kp1.public.to_bytes().to_vec()),
+            PrivateKey::new(kp1.secret.to_bytes().to_vec()),
         );
 
         // initial signing key prefix
@@ -499,21 +494,21 @@ mod tests {
         let kp2 = Keypair::generate(&mut OsRng);
 
         // get two ed25519 keypairs
-        let pub_key0 = Key::new(kp0.public.to_bytes().to_vec());
-        let priv_key0 = Key::new(kp0.secret.to_bytes().to_vec());
+        let pub_key0 = PublicKey::new(kp0.public.to_bytes().to_vec());
+        let priv_key0 = PrivateKey::new(kp0.secret.to_bytes().to_vec());
         let (pub_key1, sig_key_1) = (
-            Key::new(kp1.public.to_bytes().to_vec()),
-            Key::new(kp1.secret.to_bytes().to_vec()),
+            PublicKey::new(kp1.public.to_bytes().to_vec()),
+            PrivateKey::new(kp1.secret.to_bytes().to_vec()),
         );
 
         // hi X!
         // let x = XChaCha20Poly1305::new((&priv_key0.into_bytes()[..]).into());
 
         // get two X25519 keypairs
-        let (enc_key_0, _enc_priv_0) = (Key::new(kp2.public.to_bytes().to_vec()), sig_key_1);
+        let (enc_key_0, _enc_priv_0) = (PublicKey::new(kp2.public.to_bytes().to_vec()), sig_key_1);
         let (enc_key_1, _enc_priv_1) = (
-            Key::new(kp2.public.to_bytes().to_vec()),
-            Key::new(kp2.secret.to_bytes().to_vec()),
+            PublicKey::new(kp2.public.to_bytes().to_vec()),
+            PrivateKey::new(kp2.secret.to_bytes().to_vec()),
         );
 
         // initial key set

--- a/src/event_message/tests/test_utils.rs
+++ b/src/event_message/tests/test_utils.rs
@@ -1,12 +1,5 @@
 use super::event_msg_builder::{EventMsgBuilder, EventType};
-use crate::{
-    derivation::{basic::Basic, self_addressing::SelfAddressing, self_signing::SelfSigning},
-    error::Error,
-    event::sections::{key_config::nxt_commitment, threshold::SignatureThreshold},
-    keys::Key,
-    prefix::{AttachedSignaturePrefix, BasicPrefix, IdentifierPrefix, SelfAddressingPrefix},
-    state::IdentifierState,
-};
+use crate::{derivation::{basic::Basic, self_addressing::SelfAddressing, self_signing::SelfSigning}, error::Error, event::sections::{key_config::nxt_commitment, threshold::SignatureThreshold}, keys::PrivateKey, prefix::{AttachedSignaturePrefix, BasicPrefix, IdentifierPrefix, SelfAddressingPrefix, basic::PublicKey}, state::IdentifierState};
 use ed25519_dalek::Keypair;
 use rand::rngs::OsRng;
 
@@ -20,16 +13,16 @@ pub struct TestStateData {
     keys_history: Vec<BasicPrefix>,
     prev_event_hash: SelfAddressingPrefix,
     sn: u64,
-    current_keypair: (Key, Key),
-    new_keypair: (Key, Key),
+    current_keypair: (PublicKey, PrivateKey),
+    new_keypair: (PublicKey, PrivateKey),
 }
 
 /// Create initial `TestStateData`, before application of any Event.
 /// Provides only keypair for next event.
 fn get_initial_test_data() -> Result<TestStateData, Error> {
     let keypair = Keypair::generate(&mut OsRng);
-    let pk = Key::new(keypair.public.as_bytes().to_vec());
-    let sk = Key::new(keypair.secret.as_bytes().to_vec());
+    let pk = PublicKey::new(keypair.public.as_bytes().to_vec());
+    let sk = PrivateKey::new(keypair.secret.as_bytes().to_vec());
 
     Ok(TestStateData {
         state: IdentifierState::default(),
@@ -57,8 +50,8 @@ fn test_update_identifier_state(
         cur_pk = next_pk;
         cur_sk = next_sk;
         let keypair = Keypair::generate(&mut OsRng);
-        let pk = Key::new(keypair.public.as_bytes().to_vec());
-        let sk = Key::new(keypair.secret.as_bytes().to_vec());
+        let pk = PublicKey::new(keypair.public.as_bytes().to_vec());
+        let sk = PrivateKey::new(keypair.secret.as_bytes().to_vec());
         next_pk = pk;
         next_sk = sk;
     };

--- a/src/event_message/tests/test_utils.rs
+++ b/src/event_message/tests/test_utils.rs
@@ -1,5 +1,5 @@
 use super::event_msg_builder::{EventMsgBuilder, EventType};
-use crate::{derivation::{basic::Basic, self_addressing::SelfAddressing, self_signing::SelfSigning}, error::Error, event::sections::{key_config::nxt_commitment, threshold::SignatureThreshold}, keys::PrivateKey, prefix::{AttachedSignaturePrefix, BasicPrefix, IdentifierPrefix, SelfAddressingPrefix, basic::PublicKey}, state::IdentifierState};
+use crate::{derivation::{basic::Basic, self_addressing::SelfAddressing, self_signing::SelfSigning}, error::Error, event::sections::{key_config::nxt_commitment, threshold::SignatureThreshold}, keys::{PrivateKey, PublicKey}, prefix::{AttachedSignaturePrefix, BasicPrefix, IdentifierPrefix, SelfAddressingPrefix }, state::IdentifierState};
 use ed25519_dalek::Keypair;
 use rand::rngs::OsRng;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,4 +10,4 @@ pub mod processor;
 pub mod signer;
 pub mod state;
 
-pub(crate) mod keys;
+pub mod keys;

--- a/src/prefix/basic.rs
+++ b/src/prefix/basic.rs
@@ -1,21 +1,67 @@
 use super::{verify, Prefix, SelfSigningPrefix};
-use crate::{
-    derivation::{basic::Basic, DerivationCode},
-    error::Error,
-    keys::Key,
-};
+use crate::{derivation::{basic::Basic, DerivationCode}, error::Error, };
 use base64::decode_config;
 use core::str::FromStr;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use k256::ecdsa::{VerifyingKey, signature::{Verifier as EcdsaVerifier}};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PublicKey {
+    public_key: Vec<u8>
+}
+
+impl PublicKey {
+    pub fn new(key: Vec<u8>) -> Self {
+        PublicKey {public_key: key.to_vec()}
+    }
+
+    pub fn key(&self) -> Vec<u8> {
+        self.public_key.clone()
+    }
+
+    pub fn verify_ed(&self, msg: &[u8], sig: &[u8]) -> bool {
+        if let Ok(key) = ed25519_dalek::PublicKey::from_bytes(&self.key()) {
+            use arrayref::array_ref;
+            if sig.len() != 64 {
+                return false;
+            }
+            let sig = ed25519_dalek::Signature::from(array_ref!(sig, 0, 64).to_owned());
+            match key.verify(msg, &sig) {
+                Ok(()) => true,
+                Err(_) => false,
+            }
+        } else {
+            false
+        }
+    }
+
+    pub fn verify_ecdsa(&self, msg: &[u8], sig: &[u8]) -> bool {
+        match VerifyingKey::from_sec1_bytes(&self.key()) {
+            Ok(k) => {
+                use k256::ecdsa::Signature;
+                use std::convert::TryFrom;
+                if let Ok(sig) = Signature::try_from(sig) {
+                    match k.verify(msg, &sig) {
+                        Ok(()) => true,
+                        Err(_) => false,
+                    }
+                } else {
+                    false
+                }
+            }
+            Err(_) => false,
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct BasicPrefix {
     pub derivation: Basic,
-    pub public_key: Key,
+    pub public_key: PublicKey,
 }
 
 impl BasicPrefix {
-    pub fn new(code: Basic, public_key: Key) -> Self {
+    pub fn new(code: Basic, public_key: PublicKey) -> Self {
         Self {
             derivation: code,
             public_key,
@@ -42,7 +88,7 @@ impl FromStr for BasicPrefix {
         if s.len() == code.prefix_b64_len() {
             let k_vec =
                 decode_config(&s[code.code_len()..code.prefix_b64_len()], base64::URL_SAFE)?;
-            Ok(Self::new(code, Key::new(k_vec)))
+            Ok(Self::new(code, PublicKey::new(k_vec)))
         } else {
             Err(Error::SemanticError(format!(
                 "Incorrect Prefix Length: {}",
@@ -92,7 +138,7 @@ fn serialize_deserialize() {
 
     let bp = BasicPrefix {
         derivation: Basic::Ed25519,
-        public_key: Key::new(kp.public.to_bytes().to_vec()),
+        public_key: PublicKey::new(kp.public.to_bytes().to_vec()),
     };
 
     let serialized = serde_json::to_string(&bp);
@@ -108,10 +154,11 @@ fn serialize_deserialize() {
 fn to_from_string() {
     use ed25519_dalek::Keypair;
     use rand::rngs::OsRng;
+    use crate::keys::PrivateKey;
 
     let kp = Keypair::generate(&mut OsRng);
 
-    let signer = Key::new(kp.secret.to_bytes().to_vec());
+    let signer = PrivateKey::new(kp.secret.to_bytes().to_vec());
 
     let message = b"hello there";
     let sig = SelfSigningPrefix::new(
@@ -121,7 +168,7 @@ fn to_from_string() {
 
     let bp = BasicPrefix {
         derivation: Basic::Ed25519,
-        public_key: Key::new(kp.public.to_bytes().to_vec()),
+        public_key: PublicKey::new(kp.public.to_bytes().to_vec()),
     };
 
     assert!(bp.verify(message, &sig).unwrap());

--- a/src/prefix/basic.rs
+++ b/src/prefix/basic.rs
@@ -1,58 +1,8 @@
 use super::{verify, Prefix, SelfSigningPrefix};
-use crate::{derivation::{basic::Basic, DerivationCode}, error::Error, };
+use crate::{derivation::{basic::Basic, DerivationCode}, error::Error, keys::PublicKey};
 use base64::decode_config;
 use core::str::FromStr;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use k256::ecdsa::{VerifyingKey, signature::{Verifier as EcdsaVerifier}};
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct PublicKey {
-    public_key: Vec<u8>
-}
-
-impl PublicKey {
-    pub fn new(key: Vec<u8>) -> Self {
-        PublicKey {public_key: key.to_vec()}
-    }
-
-    pub fn key(&self) -> Vec<u8> {
-        self.public_key.clone()
-    }
-
-    pub fn verify_ed(&self, msg: &[u8], sig: &[u8]) -> bool {
-        if let Ok(key) = ed25519_dalek::PublicKey::from_bytes(&self.key()) {
-            use arrayref::array_ref;
-            if sig.len() != 64 {
-                return false;
-            }
-            let sig = ed25519_dalek::Signature::from(array_ref!(sig, 0, 64).to_owned());
-            match key.verify(msg, &sig) {
-                Ok(()) => true,
-                Err(_) => false,
-            }
-        } else {
-            false
-        }
-    }
-
-    pub fn verify_ecdsa(&self, msg: &[u8], sig: &[u8]) -> bool {
-        match VerifyingKey::from_sec1_bytes(&self.key()) {
-            Ok(k) => {
-                use k256::ecdsa::Signature;
-                use std::convert::TryFrom;
-                if let Ok(sig) = Signature::try_from(sig) {
-                    match k.verify(msg, &sig) {
-                        Ok(()) => true,
-                        Err(_) => false,
-                    }
-                } else {
-                    false
-                }
-            }
-            Err(_) => false,
-        }
-    }
-}
 
 #[derive(Debug, Clone)]
 pub struct BasicPrefix {

--- a/src/prefix/mod.rs
+++ b/src/prefix/mod.rs
@@ -147,8 +147,8 @@ pub fn derive(seed: &SeedPrefix, transferable: bool) -> Result<BasicPrefix, Erro
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{derivation::self_addressing::SelfAddressing, keys::Key};
-    use ed25519_dalek::{Keypair, PublicKey};
+    use crate::{derivation::self_addressing::SelfAddressing, keys::PrivateKey, prefix::basic::PublicKey};
+    use ed25519_dalek::{Keypair};
     use rand::rngs::OsRng;
 
     #[test]
@@ -193,8 +193,8 @@ mod tests {
 
     #[test]
     fn simple_serialize() -> Result<(), Error> {
-        let pref = Basic::Ed25519NT.derive(Key::new(
-            PublicKey::from_bytes(&[0; 32])?.to_bytes().to_vec(),
+        let pref = Basic::Ed25519NT.derive(PublicKey::new(
+            ed25519_dalek::PublicKey::from_bytes(&[0; 32])?.to_bytes().to_vec(),
         ));
 
         assert_eq!(
@@ -210,8 +210,8 @@ mod tests {
         let data_string = "hello there";
 
         let kp = Keypair::generate(&mut OsRng);
-        let pub_key = Key::new(kp.public.to_bytes().to_vec());
-        let priv_key = Key::new(kp.secret.to_bytes().to_vec());
+        let pub_key = PublicKey::new(kp.public.to_bytes().to_vec());
+        let priv_key = PrivateKey::new(kp.secret.to_bytes().to_vec());
 
         let key_prefix = Basic::Ed25519NT.derive(pub_key);
 
@@ -286,7 +286,7 @@ mod tests {
         assert_eq!(
             BasicPrefix::new(
                 Basic::Ed25519NT,
-                Key::new(PublicKey::from_bytes(&[0; 32])?.to_bytes().to_vec())
+                PublicKey::new(ed25519_dalek::PublicKey::from_bytes(&[0; 32])?.to_bytes().to_vec())
             )
             .to_str(),
             ["B".to_string(), "A".repeat(43)].join("")
@@ -294,7 +294,7 @@ mod tests {
         assert_eq!(
             BasicPrefix::new(
                 Basic::X25519,
-                Key::new(PublicKey::from_bytes(&[0; 32])?.to_bytes().to_vec())
+                PublicKey::new(ed25519_dalek::PublicKey::from_bytes(&[0; 32])?.to_bytes().to_vec())
             )
             .to_str(),
             ["C".to_string(), "A".repeat(43)].join("")
@@ -302,29 +302,29 @@ mod tests {
         assert_eq!(
             BasicPrefix::new(
                 Basic::Ed25519,
-                Key::new(PublicKey::from_bytes(&[0; 32])?.to_bytes().to_vec())
+                PublicKey::new(ed25519_dalek::PublicKey::from_bytes(&[0; 32])?.to_bytes().to_vec())
             )
             .to_str(),
             ["D".to_string(), "A".repeat(43)].join("")
         );
         assert_eq!(
-            BasicPrefix::new(Basic::X448, Key::new([0; 56].to_vec())).to_str(),
+            BasicPrefix::new(Basic::X448, PublicKey::new([0; 56].to_vec())).to_str(),
             ["L".to_string(), "A".repeat(75)].join("")
         );
         assert_eq!(
-            BasicPrefix::new(Basic::ECDSAsecp256k1NT, Key::new([0; 33].to_vec())).to_str(),
+            BasicPrefix::new(Basic::ECDSAsecp256k1NT, PublicKey::new([0; 33].to_vec())).to_str(),
             ["1AAA".to_string(), "A".repeat(44)].join("")
         );
         assert_eq!(
-            BasicPrefix::new(Basic::ECDSAsecp256k1, Key::new([0; 33].to_vec())).to_str(),
+            BasicPrefix::new(Basic::ECDSAsecp256k1, PublicKey::new([0; 33].to_vec())).to_str(),
             ["1AAB".to_string(), "A".repeat(44)].join("")
         );
         assert_eq!(
-            BasicPrefix::new(Basic::Ed448NT, Key::new([0; 57].to_vec())).to_str(),
+            BasicPrefix::new(Basic::Ed448NT, PublicKey::new([0; 57].to_vec())).to_str(),
             ["1AAC".to_string(), "A".repeat(76)].join("")
         );
         assert_eq!(
-            BasicPrefix::new(Basic::Ed448, Key::new([0; 57].to_vec())).to_str(),
+            BasicPrefix::new(Basic::Ed448, PublicKey::new([0; 57].to_vec())).to_str(),
             ["1AAD".to_string(), "A".repeat(76)].join("")
         );
 

--- a/src/prefix/mod.rs
+++ b/src/prefix/mod.rs
@@ -147,7 +147,7 @@ pub fn derive(seed: &SeedPrefix, transferable: bool) -> Result<BasicPrefix, Erro
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{derivation::self_addressing::SelfAddressing, keys::PrivateKey, prefix::basic::PublicKey};
+    use crate::{derivation::self_addressing::SelfAddressing, keys::{PrivateKey, PublicKey}};
     use ed25519_dalek::{Keypair};
     use rand::rngs::OsRng;
 

--- a/src/prefix/parse.rs
+++ b/src/prefix/parse.rs
@@ -2,7 +2,7 @@
 use crate::{derivation::{
         attached_signature_code::b64_to_num, basic::Basic, self_addressing::SelfAddressing,
         self_signing::SelfSigning, DerivationCode,
-    }, error::Error, event::sections::seal::EventSeal, prefix::{AttachedSignaturePrefix, BasicPrefix, IdentifierPrefix, SelfSigningPrefix, basic::PublicKey}};
+    }, error::Error, event::sections::seal::EventSeal, keys::PublicKey, prefix::{AttachedSignaturePrefix, BasicPrefix, IdentifierPrefix, SelfSigningPrefix}};
 use base64::URL_SAFE;
 use nom::{bytes::complete::take, error::ErrorKind};
 

--- a/src/prefix/parse.rs
+++ b/src/prefix/parse.rs
@@ -1,14 +1,8 @@
 #![allow(non_upper_case_globals)]
-use crate::{
-    derivation::{
+use crate::{derivation::{
         attached_signature_code::b64_to_num, basic::Basic, self_addressing::SelfAddressing,
         self_signing::SelfSigning, DerivationCode,
-    },
-    error::Error,
-    event::sections::seal::EventSeal,
-    keys::Key,
-    prefix::{AttachedSignaturePrefix, BasicPrefix, IdentifierPrefix, SelfSigningPrefix},
-};
+    }, error::Error, event::sections::seal::EventSeal, prefix::{AttachedSignaturePrefix, BasicPrefix, IdentifierPrefix, SelfSigningPrefix, basic::PublicKey}};
 use base64::URL_SAFE;
 use nom::{bytes::complete::take, error::ErrorKind};
 
@@ -97,7 +91,7 @@ pub fn basic_prefix(s: &[u8]) -> nom::IResult<&[u8], BasicPrefix> {
         .map_err(|_| nom::Err::Failure((s, ErrorKind::IsNot)))?;
 
     let (extra, b) = take(code.derivative_b64_len())(rest)?;
-    let pk = Key::new(base64::decode_config(b.to_vec(), URL_SAFE).unwrap());
+    let pk = PublicKey::new(base64::decode_config(b.to_vec(), URL_SAFE).unwrap());
     Ok((extra, code.derive(pk)))
 }
 
@@ -222,7 +216,7 @@ fn test_basic_prefix() {
 
     let bp = BasicPrefix {
         derivation: Basic::Ed25519,
-        public_key: Key::new(kp.public.to_bytes().to_vec()),
+        public_key: PublicKey::new(kp.public.to_bytes().to_vec()),
     };
     let bp_str = [&bp.to_str(), "more"].join("");
     let parsed = basic_prefix(bp_str.as_bytes()).unwrap();

--- a/src/prefix/seed.rs
+++ b/src/prefix/seed.rs
@@ -1,5 +1,5 @@
-use super::{Prefix, basic::PublicKey};
-use crate::{error::Error, keys::PrivateKey};
+use super::Prefix;
+use crate::{error::Error, keys::{PrivateKey, PublicKey}};
 use base64::decode_config;
 use core::str::FromStr;
 use ed25519_dalek::{SecretKey};

--- a/src/prefix/seed.rs
+++ b/src/prefix/seed.rs
@@ -1,8 +1,8 @@
-use super::Prefix;
-use crate::{error::Error, keys::Key};
+use super::{Prefix, basic::PublicKey};
+use crate::{error::Error, keys::PrivateKey};
 use base64::decode_config;
 use core::str::FromStr;
-use ed25519_dalek::{PublicKey, SecretKey};
+use ed25519_dalek::{SecretKey};
 use k256::ecdsa::{SigningKey, VerifyingKey};
 
 #[derive(Debug, PartialEq, Clone)]
@@ -14,19 +14,19 @@ pub enum SeedPrefix {
 }
 
 impl SeedPrefix {
-    pub fn derive_key_pair(&self) -> Result<(Key, Key), Error> {
+    pub fn derive_key_pair(&self) -> Result<(PublicKey, PrivateKey), Error> {
         match self {
             Self::RandomSeed256Ed25519(seed) => {
                 let secret = SecretKey::from_bytes(seed)?;
-                let vk = Key::new(PublicKey::from(&secret).as_bytes().to_vec());
-                let sk = Key::new(secret.as_bytes().to_vec());
+                let vk = PublicKey::new(ed25519_dalek::PublicKey::from(&secret).as_bytes().to_vec());
+                let sk = PrivateKey::new(secret.as_bytes().to_vec());
                 Ok((vk, sk))
             }
             Self::RandomSeed256ECDSAsecp256k1(seed) => {
                 let sk = SigningKey::from_bytes(&seed)?;
                 Ok((
-                    Key::new(VerifyingKey::from(&sk).to_bytes().to_vec()),
-                    Key::new(sk.to_bytes().to_vec()),
+                    PublicKey::new(VerifyingKey::from(&sk).to_bytes().to_vec()),
+                    PrivateKey::new(sk.to_bytes().to_vec()),
                 ))
             }
             _ => Err(Error::ImproperPrefixType),

--- a/src/signer/mod.rs
+++ b/src/signer/mod.rs
@@ -12,7 +12,7 @@ pub struct CryptoBox {
     signer: Signer,
     next_priv_key: Key,
     pub next_pub_key: Key,
-    seeds: Vec<String>,
+    seeds: Box<dyn Iterator<Item = SeedPrefix>>,
 }
 
 impl KeyManager for CryptoBox {
@@ -29,17 +29,10 @@ impl KeyManager for CryptoBox {
     }
 
     fn rotate(&mut self) -> Result<(), Error> {
-        let (next_pub_key, next_priv_key) =
-            if let Some((next_secret, next_seeds)) = self.seeds.split_first() {
-                let next_secret: SeedPrefix = next_secret.parse()?;
-                self.seeds = next_seeds.to_vec();
-                next_secret.derive_key_pair()?
-            } else {
-                let kp = Keypair::generate(&mut OsRng {});
-                let vk = Key::new(kp.public.as_bytes().to_vec());
-                let sk = Key::new(kp.secret.as_bytes().to_vec());
-                (vk, sk)
-            };
+        let (next_pub_key, next_priv_key) = {
+            let nxt_key_seed = self.seeds.next();
+            derive_key_pair(nxt_key_seed)?
+        };
 
         let new_signer = Signer {
             priv_key: self.next_priv_key.clone(),
@@ -55,60 +48,27 @@ impl KeyManager for CryptoBox {
 //#[cfg(feature = "demo")]
 impl CryptoBox {
     pub fn new() -> Result<Self, Error> {
-        let signer = Signer::new()?;
-        let kp = Keypair::generate(&mut OsRng {});
-        let (next_pub_key, next_priv_key) = (
-            Key::new(kp.public.as_bytes().to_vec()),
-            Key::new(kp.secret.as_bytes().to_vec()),
-        );
+        let signer = Signer::new();
+        let (next_pub_key, next_priv_key) = derive_key_pair(None)?;
         Ok(CryptoBox {
             signer,
             next_pub_key,
             next_priv_key,
-            seeds: vec![],
+            seeds: Box::new(std::iter::empty()),
         })
     }
 
-    pub fn derive_from_seed(seeds: &[&str]) -> Result<Self, Error> {
-        let (pub_key, priv_key) = match seeds.get(0) {
-            Some(secret) => {
-                let secret = SecretKey::from_bytes(secret.as_bytes()).map_err(|_| {
-                    Error::SemanticError("failed to convert provided seet to SecretKey".into())
-                })?;
-                let public = PublicKey::from(&secret);
-                (public, secret)
-            }
-            None => ed_new_public_private(),
-        };
+    pub fn derive_from_seed(seeds: Vec<SeedPrefix>) -> Result<Self, Error> {
+        let mut seeds = seeds.into_iter();
+        let (pub_key, priv_key) = derive_key_pair(seeds.next())?;
 
-        let (next_pub_key, next_priv_key) = match seeds.get(1) {
-            Some(secret) => {
-                let seed: SeedPrefix = secret.parse()?;
-                seed.derive_key_pair()?
-            }
-            None => {
-                let (vk, sk) = ed_new_public_private();
-                let vk = Key::new(vk.to_bytes().to_vec());
-                let sk = Key::new(sk.to_bytes().to_vec());
-                (vk, sk)
-            }
-        };
-
-        let seeds = seeds
-            .get(2..)
-            .unwrap_or(&vec![])
-            .iter()
-            .map(|s| s.to_string())
-            .collect();
+        let (next_pub_key, next_priv_key) = derive_key_pair(seeds.next())?;
 
         Ok(CryptoBox {
-            signer: Signer {
-                pub_key: Key::new(pub_key.to_bytes().to_vec()),
-                priv_key: Key::new(priv_key.to_bytes().to_vec()),
-            },
+            signer: Signer { pub_key, priv_key },
             next_pub_key,
             next_priv_key,
-            seeds,
+            seeds: Box::new(seeds),
         })
     }
 }
@@ -119,12 +79,12 @@ struct Signer {
 }
 
 impl Signer {
-    pub fn new() -> Result<Self, Error> {
-        let ed = Keypair::generate(&mut OsRng);
-        let pub_key = Key::new(ed.public.to_bytes().to_vec());
-        let priv_key = Key::new(ed.secret.to_bytes().to_vec());
+    pub fn new() -> Self {
+        let (pk, sk) = ed_new_public_private();
+        let pub_key = Key::new(pk.to_bytes().to_vec());
+        let priv_key = Key::new(sk.to_bytes().to_vec());
 
-        Ok(Signer { pub_key, priv_key })
+        Signer { pub_key, priv_key }
     }
 
     pub fn sign(&self, msg: &Vec<u8>) -> Result<Vec<u8>, Error> {
@@ -135,4 +95,68 @@ impl Signer {
 fn ed_new_public_private() -> (PublicKey, SecretKey) {
     let kp = Keypair::generate(&mut OsRng {});
     (kp.public, kp.secret)
+}
+
+fn derive_key_pair(seed: Option<SeedPrefix>) -> Result<(Key, Key), Error> {
+    match seed {
+        Some(secret) => secret.derive_key_pair(),
+        None => {
+            let (vk, sk) = ed_new_public_private();
+            let vk = Key::new(vk.to_bytes().to_vec());
+            let sk = Key::new(sk.to_bytes().to_vec());
+            Ok((vk, sk))
+        }
+    }
+}
+
+#[test]
+fn test_derive_keypairs_from_seed() -> Result<(), Error> {
+    use base64;
+    // taken from KERIPY: tests/core/test_eventing.py#1512
+    let seeds = vec![
+        "ArwXoACJgOleVZ2PY7kXn7rA0II0mHYDhc6WrBH8fDAc",
+        "A6zz7M08-HQSFq92sJ8KJOT2cZ47x7pXFQLPB0pckB3Q",
+        "AcwFTk-wgk3ZT2buPRIbK-zxgPx-TKbaegQvPEivN90Y",
+        "Alntkt3u6dDgiQxTATr01dy8M72uuaZEf9eTdM-70Gk8",
+    ];
+
+    let expected_pubkeys = vec![
+        "SuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA=",
+        "VcuJOOJF1IE8svqEtrSuyQjGTd2HhfAkt9y2QkUtFJI=",
+        "T1iAhBWCkvChxNWsby2J0pJyxBIxbAtbLA0Ljx-Grh8=",
+        "KPE5eeJRzkRTMOoRGVd2m18o8fLqM2j9kaxLhV3x8AQ=",
+    ];
+
+    let mut cryptobox =
+        CryptoBox::derive_from_seed(seeds.iter().map(|seed| seed.parse().unwrap()).collect())?;
+    assert_eq!(
+        base64::encode_config(cryptobox.public_key().key(), base64::URL_SAFE),
+        expected_pubkeys[0]
+    );
+    assert_eq!(
+        base64::encode_config(cryptobox.next_public_key().key(), base64::URL_SAFE),
+        expected_pubkeys[1]
+    );
+
+    cryptobox.rotate()?;
+    assert_eq!(
+        base64::encode_config(cryptobox.public_key().key(), base64::URL_SAFE),
+        expected_pubkeys[1]
+    );
+    assert_eq!(
+        base64::encode_config(cryptobox.next_public_key().key(), base64::URL_SAFE),
+        expected_pubkeys[2]
+    );
+
+    cryptobox.rotate()?;
+    assert_eq!(
+        base64::encode_config(cryptobox.public_key().key(), base64::URL_SAFE),
+        expected_pubkeys[2]
+    );
+    assert_eq!(
+        base64::encode_config(cryptobox.next_public_key().key(), base64::URL_SAFE),
+        expected_pubkeys[3]
+    );
+
+    Ok(())
 }

--- a/src/signer/mod.rs
+++ b/src/signer/mod.rs
@@ -1,4 +1,4 @@
-use crate::{error::Error, keys::PrivateKey, prefix::{SeedPrefix, basic::PublicKey}};
+use crate::{error::Error, keys::{PrivateKey, PublicKey}, prefix::{SeedPrefix}};
 use ed25519_dalek::{Keypair, SecretKey};
 use rand::rngs::OsRng;
 pub trait KeyManager {


### PR DESCRIPTION
Changes:
* make keys module public to be able to use it from outside of keriox, for example to derive `BasicPrefix` or implement `KeyManager` trait,
* split `Key` into `PublicKey` and `PrivateKey`,
* refactor `CryproBox` structure.