### PR TITLE
Make sled event tree vec public

### DIFF
--- a/src/database/sled/mod.rs
+++ b/src/database/sled/mod.rs
@@ -1,4 +1,4 @@
-mod tables;
+pub mod tables;
 
 use crate::{
     error::Error,
@@ -21,7 +21,7 @@ use crate::query::reply::SignedReply;
 
 pub struct SledEventDatabase {
     // "iids" tree
-    // this thing is expensive, but everything else is cheeeeeep
+    // this thing is expensive, but everything else is cheap
     identifiers: SledEventTree<IdentifierPrefix>,
     // "kels" tree
     key_event_logs: SledEventTreeVec<TimestampedSignedEventMessage>,

--- a/src/event/sections/threshold.rs
+++ b/src/event/sections/threshold.rs
@@ -196,8 +196,8 @@ impl MultiClauses {
             .fold(Ok((0, true)), |acc, clause| -> Result<_, Error> {
                 let (start, enough) = acc?;
                 let sigs: Vec<AttachedSignaturePrefix> = sigs
-                    .to_owned()
-                    .into_iter()
+                    .iter()
+                    .cloned()
                     .filter(|sig| sig.index >= start && sig.index < start + clause.0.len() as u16)
                     .collect();
                 Ok((

--- a/src/event_parsing/prefix.rs
+++ b/src/event_parsing/prefix.rs
@@ -97,8 +97,7 @@ pub fn basic_prefix(s: &[u8]) -> nom::IResult<&[u8], BasicPrefix> {
 
     let (extra, b) = take(code.derivative_b64_len())(rest)?;
     let pk = PublicKey::new(
-        base64::decode_config(b.to_vec(), URL_SAFE)
-            .map_err(|_| nom::Err::Error((s, ErrorKind::IsNot)))?,
+        base64::decode_config(b, URL_SAFE).map_err(|_| nom::Err::Error((s, ErrorKind::IsNot)))?,
     );
     Ok((extra, code.derive(pk)))
 }

--- a/src/prefix/mod.rs
+++ b/src/prefix/mod.rs
@@ -172,21 +172,21 @@ mod tests {
         assert!(IdentifierPrefix::from_str("CBBBBBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").is_ok());
 
         // too short
-        assert!(!IdentifierPrefix::from_str("BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").is_ok());
+        assert!(IdentifierPrefix::from_str("BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").is_err());
 
         // too long
         assert!(
-            !IdentifierPrefix::from_str("BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").is_ok()
+            IdentifierPrefix::from_str("BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").is_err()
         );
 
         // not a real prefix
         assert!(
-            !IdentifierPrefix::from_str("ZAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").is_ok()
+            IdentifierPrefix::from_str("ZAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").is_err()
         );
 
         // not base 64 URL
         assert!(
-            !IdentifierPrefix::from_str("BAAAAAAAAAAAAAAAAAAA/AAAAAAAAAAAAAAAAAAAAAAAA").is_ok()
+            IdentifierPrefix::from_str("BAAAAAAAAAAAAAAAAAAA/AAAAAAAAAAAAAAAAAAAAAAAA").is_err()
         );
 
         Ok(())


### PR DESCRIPTION
This allows the crate users to use the public APIs for the `SledEventTree` and `SledEventTreeVec` structs instead of redefining similar APIs.